### PR TITLE
feat: make test-design QA outputs less prescriptive + add sprint handoff

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -28,6 +28,7 @@ Complete reference for all TEA (Test Engineering Architect) configuration option
 project_name: my-awesome-app
 user_skill_level: intermediate
 output_folder: _bmad-output
+test_artifacts: _bmad-output/test-artifacts
 tea_use_playwright_utils: true
 tea_use_mcp_enhancements: false
 ```
@@ -49,6 +50,26 @@ tea_use_mcp_enhancements: false
 ---
 
 ## TEA Configuration Options
+
+### test_artifacts
+
+Base output folder for TEA-generated artifacts (test designs, reports, traceability, etc).
+
+**Schema Location:** `src/module.yaml` (TEA module config)
+
+**User Config:** `_bmad/tea/config.yaml`
+
+**Type:** `string`
+
+**Default:** `{output_folder}/test-artifacts`
+
+**Purpose:** Allows TEA outputs to live outside the core BMM output folder.
+
+**Example:**
+
+```yaml
+test_artifacts: docs/testing-artifacts
+```
 
 ### tea_use_playwright_utils
 
@@ -204,7 +225,7 @@ TEA also uses core BMM configuration options from `_bmad/tea/config.yaml`:
 
 **Default:** `_bmad-output`
 
-**Purpose:** Where TEA writes output files (test designs, reports, traceability matrices)
+**Purpose:** Base output folder for core BMM artifacts. TEA writes test artifacts under `test_artifacts` (defaults to `{output_folder}/test-artifacts`).
 
 **Example:**
 
@@ -212,7 +233,7 @@ TEA also uses core BMM configuration options from `_bmad/tea/config.yaml`:
 output_folder: _bmad-output
 ```
 
-**TEA Output Files:**
+**TEA Output Files (under `{test_artifacts}`):**
 
 - `test-design-architecture.md` + `test-design-qa.md` (from `test-design` system-level - TWO documents)
 - `test-design-epic-N.md` (from `test-design` epic-level)

--- a/src/workflows/testarch/README.md
+++ b/src/workflows/testarch/README.md
@@ -70,5 +70,5 @@ This folder contains the Test Architect (TEA) workflows converted to step-file a
 ## Notes
 
 - `workflow.md` is the canonical entrypoint. `instructions.md` is a short summary for quick context.
-- Output files typically use `{output_folder}` or `{project-root}` variables.
+- Output files typically use `{test_artifacts}` or `{project-root}` variables.
 - If a workflow produces multiple artifacts (e.g., system-level vs epic-level), the step file will specify which templates and output paths to use.

--- a/src/workflows/testarch/atdd/checklist.md
+++ b/src/workflows/testarch/atdd/checklist.md
@@ -170,7 +170,7 @@ Before starting this workflow, verify:
 
 ### ATDD Checklist Document Created
 
-- [ ] Output file created at `{output_folder}/atdd-checklist-{story_id}.md`
+- [ ] Output file created at `{test_artifacts}/atdd-checklist-{story_id}.md`
 - [ ] Document follows template structure from `atdd-checklist-template.md`
 - [ ] Document includes all required sections:
   - [ ] Story summary

--- a/src/workflows/testarch/atdd/instructions.md
+++ b/src/workflows/testarch/atdd/instructions.md
@@ -29,7 +29,7 @@ This workflow uses **step-file architecture**:
 
 From `workflow.yaml`, resolve:
 
-- `config_source`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `date`
+- `config_source`, `test_artifacts`, `user_name`, `communication_language`, `document_output_language`, `date`
 - `test_dir`
 
 ### 2. First Step

--- a/src/workflows/testarch/atdd/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/atdd/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{output_folder}/atdd-validation-report.md'
+outputFile: '{test_artifacts}/atdd-validation-report.md'
 validationChecklist: '../checklist.md'
 ---
 

--- a/src/workflows/testarch/atdd/workflow-plan.md
+++ b/src/workflows/testarch/atdd/workflow-plan.md
@@ -16,6 +16,6 @@
   - step-02-apply-edit.md
 
   ## Outputs
-  - {output_folder}/atdd-checklist-{story_id}.md
+  - {test_artifacts}/atdd-checklist-{story_id}.md
 
 - Failing acceptance tests under {project-root}/tests

--- a/src/workflows/testarch/atdd/workflow.yaml
+++ b/src/workflows/testarch/atdd/workflow.yaml
@@ -6,6 +6,7 @@ author: "BMad"
 # Critical variables from config
 config_source: "{project-root}/_bmad/tea/config.yaml"
 output_folder: "{config_source}:output_folder"
+test_artifacts: "{config_source}:test_artifacts"
 user_name: "{config_source}:user_name"
 communication_language: "{config_source}:communication_language"
 document_output_language: "{config_source}:document_output_language"
@@ -22,7 +23,7 @@ variables:
   test_dir: "{project-root}/tests" # Root test directory
 
 # Output configuration
-default_output_file: "{output_folder}/atdd-checklist-{story_id}.md"
+default_output_file: "{test_artifacts}/atdd-checklist-{story_id}.md"
 
 # Required tools
 required_tools:

--- a/src/workflows/testarch/automate/instructions.md
+++ b/src/workflows/testarch/automate/instructions.md
@@ -34,7 +34,7 @@ This workflow uses **step-file architecture** for disciplined execution:
 
 From `workflow.yaml`, resolve:
 
-- `config_source`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `date`
+- `config_source`, `test_artifacts`, `user_name`, `communication_language`, `document_output_language`, `date`
 - `test_dir`, `source_dir`, `coverage_target`, `standalone_mode`
 
 ### 2. First Step

--- a/src/workflows/testarch/automate/steps-c/step-04-validate-and-summarize.md
+++ b/src/workflows/testarch/automate/steps-c/step-04-validate-and-summarize.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-04-validate-and-summarize'
 description: 'Validate outputs and produce automation summary'
-outputFile: '{output_folder}/automation-summary.md'
+outputFile: '{test_artifacts}/automation-summary.md'
 ---
 
 # Step 4: Validate & Summarize

--- a/src/workflows/testarch/automate/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/automate/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{output_folder}/automate-validation-report.md'
+outputFile: '{test_artifacts}/automate-validation-report.md'
 validationChecklist: '../checklist.md'
 ---
 

--- a/src/workflows/testarch/automate/workflow-plan.md
+++ b/src/workflows/testarch/automate/workflow-plan.md
@@ -15,6 +15,6 @@
   - step-02-apply-edit.md
 
   ## Outputs
-  - {output_folder}/automation-summary.md
+  - {test_artifacts}/automation-summary.md
 
 - Test files under {project-root}/tests

--- a/src/workflows/testarch/automate/workflow.yaml
+++ b/src/workflows/testarch/automate/workflow.yaml
@@ -6,6 +6,7 @@ author: "BMad"
 # Critical variables from config
 config_source: "{project-root}/_bmad/tea/config.yaml"
 output_folder: "{config_source}:output_folder"
+test_artifacts: "{config_source}:test_artifacts"
 user_name: "{config_source}:user_name"
 communication_language: "{config_source}:communication_language"
 document_output_language: "{config_source}:document_output_language"
@@ -28,7 +29,7 @@ variables:
   source_dir: "{project-root}" # Source code directory (customize if needed, e.g., {project-root}/src or {project-root}/lib)
 
 # Output configuration
-default_output_file: "{output_folder}/automation-summary.md"
+default_output_file: "{test_artifacts}/automation-summary.md"
 
 # Required tools
 required_tools:

--- a/src/workflows/testarch/ci/instructions.md
+++ b/src/workflows/testarch/ci/instructions.md
@@ -29,7 +29,7 @@ This workflow uses **step-file architecture**:
 
 From `workflow.yaml`, resolve:
 
-- `config_source`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `date`
+- `config_source`, `test_artifacts`, `user_name`, `communication_language`, `document_output_language`, `date`
 - `ci_platform`, `test_dir`
 
 ### 2. First Step

--- a/src/workflows/testarch/ci/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/ci/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{output_folder}/ci-validation-report.md'
+outputFile: '{test_artifacts}/ci-validation-report.md'
 validationChecklist: '../checklist.md'
 ---
 

--- a/src/workflows/testarch/ci/workflow.yaml
+++ b/src/workflows/testarch/ci/workflow.yaml
@@ -6,6 +6,7 @@ author: "BMad"
 # Critical variables from config
 config_source: "{project-root}/_bmad/tea/config.yaml"
 output_folder: "{config_source}:output_folder"
+test_artifacts: "{config_source}:test_artifacts"
 user_name: "{config_source}:user_name"
 communication_language: "{config_source}:communication_language"
 document_output_language: "{config_source}:document_output_language"

--- a/src/workflows/testarch/framework/instructions.md
+++ b/src/workflows/testarch/framework/instructions.md
@@ -29,7 +29,7 @@ This workflow uses **step-file architecture**:
 
 From `workflow.yaml`, resolve:
 
-- `config_source`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `date`
+- `config_source`, `test_artifacts`, `user_name`, `communication_language`, `document_output_language`, `date`
 - `test_dir`, `use_typescript`, `framework_preference`, `project_size`
 
 ### 2. First Step

--- a/src/workflows/testarch/framework/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/framework/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{output_folder}/framework-validation-report.md'
+outputFile: '{test_artifacts}/framework-validation-report.md'
 validationChecklist: '../checklist.md'
 ---
 

--- a/src/workflows/testarch/framework/workflow.yaml
+++ b/src/workflows/testarch/framework/workflow.yaml
@@ -6,6 +6,7 @@ author: "BMad"
 # Critical variables from config
 config_source: "{project-root}/_bmad/tea/config.yaml"
 output_folder: "{config_source}:output_folder"
+test_artifacts: "{config_source}:test_artifacts"
 user_name: "{config_source}:user_name"
 communication_language: "{config_source}:communication_language"
 document_output_language: "{config_source}:document_output_language"

--- a/src/workflows/testarch/nfr-assess/checklist.md
+++ b/src/workflows/testarch/nfr-assess/checklist.md
@@ -227,7 +227,7 @@ Note: `nfr-assess` evaluates existing evidence; it does not run tests or CI work
 
 ### NFR Assessment Report
 
-- [ ] File created at `{output_folder}/nfr-assessment.md`
+- [ ] File created at `{test_artifacts}/nfr-assessment.md`
 - [ ] Template from `nfr-report-template.md` used
 - [ ] Executive summary included (overall status, critical issues)
 - [ ] Assessment by category included (performance, security, reliability, maintainability)

--- a/src/workflows/testarch/nfr-assess/instructions.md
+++ b/src/workflows/testarch/nfr-assess/instructions.md
@@ -27,7 +27,7 @@ This workflow uses **step-file architecture**:
 
 From `workflow.yaml`, resolve:
 
-- `config_source`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `date`
+- `config_source`, `test_artifacts`, `user_name`, `communication_language`, `document_output_language`, `date`
 - `custom_nfr_categories`
 
 ### 2. First Step

--- a/src/workflows/testarch/nfr-assess/steps-c/step-05-generate-report.md
+++ b/src/workflows/testarch/nfr-assess/steps-c/step-05-generate-report.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-05-generate-report'
 description: 'Create NFR report and validation summary'
-outputFile: '{output_folder}/nfr-assessment.md'
+outputFile: '{test_artifacts}/nfr-assessment.md'
 ---
 
 # Step 5: Generate Report & Validate

--- a/src/workflows/testarch/nfr-assess/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/nfr-assess/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{output_folder}/nfr-assess-validation-report.md'
+outputFile: '{test_artifacts}/nfr-assess-validation-report.md'
 validationChecklist: '../checklist.md'
 ---
 

--- a/src/workflows/testarch/nfr-assess/workflow-plan.md
+++ b/src/workflows/testarch/nfr-assess/workflow-plan.md
@@ -16,4 +16,4 @@
   - step-02-apply-edit.md
 
   ## Outputs
-  - {output_folder}/nfr-assessment.md
+  - {test_artifacts}/nfr-assessment.md

--- a/src/workflows/testarch/nfr-assess/workflow.yaml
+++ b/src/workflows/testarch/nfr-assess/workflow.yaml
@@ -6,6 +6,7 @@ author: "BMad"
 # Critical variables from config
 config_source: "{project-root}/_bmad/tea/config.yaml"
 output_folder: "{config_source}:output_folder"
+test_artifacts: "{config_source}:test_artifacts"
 user_name: "{config_source}:user_name"
 communication_language: "{config_source}:communication_language"
 document_output_language: "{config_source}:document_output_language"
@@ -23,7 +24,7 @@ variables:
   custom_nfr_categories: "" # Optional additional categories beyond standard (security, performance, reliability, maintainability)
 
 # Output configuration
-default_output_file: "{output_folder}/nfr-assessment.md"
+default_output_file: "{test_artifacts}/nfr-assessment.md"
 
 # Required tools
 required_tools:

--- a/src/workflows/testarch/teach-me-testing/workflow.md
+++ b/src/workflows/testarch/teach-me-testing/workflow.md
@@ -55,7 +55,7 @@ This uses **step-file architecture** for disciplined execution:
 
 Load and read full config from {project-root}/\_bmad/tea/config.yaml (or module config if TEA module installed) and resolve:
 
-- `project_name`, `output_folder`, `user_name`, `communication_language`, `test_artifacts`
+- `project_name`, `user_name`, `communication_language`, `test_artifacts`
 - TEA module variables: `test_artifacts` (base output folder for test-related artifacts)
 
 ### 2. Mode Determination

--- a/src/workflows/testarch/test-design/checklist.md
+++ b/src/workflows/testarch/test-design/checklist.md
@@ -295,7 +295,11 @@
 - [ ] **QA Effort Estimate** section (QA effort ONLY)
   - [ ] Interval-based estimates (e.g., "~1-2 weeks" NOT "36 hours")
   - [ ] NO DevOps, Backend, Data Eng, Finance effort
-  - [ ] NO Sprint breakdowns (too prescriptive)
+  - [ ] No per-sprint effort breakdowns in this section
+- [ ] **Sprint Planning Handoff** section (optional)
+  - [ ] Only include if implementation tasks must be scheduled
+  - [ ] Owners assigned (QA/Dev/Platform/etc)
+  - [ ] Target sprint may be noted, but avoid detailed per-sprint breakdowns
 - [ ] **Appendix A: Code Examples & Tagging**
 - [ ] **Appendix B: Knowledge Base References**
 
@@ -311,8 +315,8 @@
 - [ ] ❌ NO Follow-on Workflows section (BMAD commands self-explanatory)
 - [ ] ❌ NO Approval section
 - [ ] ❌ NO Infrastructure/DevOps/Finance effort tables (out of scope)
-- [ ] ❌ NO Sprint 0/1/2/3 breakdown tables
-- [ ] ❌ NO Next Steps section
+- [ ] ❌ NO detailed sprint-by-sprint breakdown tables (use Sprint Planning Handoff if needed)
+- [ ] ❌ NO generic Next Steps section (use Sprint Planning Handoff if needed)
 
 ### Cross-Document Consistency
 

--- a/src/workflows/testarch/test-design/instructions.md
+++ b/src/workflows/testarch/test-design/instructions.md
@@ -44,7 +44,7 @@ This workflow uses **step-file architecture** for disciplined execution:
 
 From `workflow.yaml`, resolve:
 
-- `config_source`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `date`
+- `config_source`, `test_artifacts`, `user_name`, `communication_language`, `document_output_language`, `date`
 
 ### 2. First Step
 
@@ -83,6 +83,13 @@ When populating templates in step 5, apply the following guidance for these sect
 - Avoid assuming specific vendors unless the project context names them
 - Mark each item's status as Ready or Pending based on available information
 - This section applies only to `test-design-qa-template.md` output
+
+### Sprint Planning Handoff (Optional)
+
+- Include only if test design produces implementation tasks that must be scheduled
+- Derive items from Dependencies & Test Blockers, tooling/access needs, and QA infra setup
+- If no dedicated QA, assign ownership to Dev/Platform as appropriate
+- Keep the list short; avoid per-sprint breakdown tables
 
 ### Interworking & Regression
 

--- a/src/workflows/testarch/test-design/steps-c/step-02-load-context.md
+++ b/src/workflows/testarch/test-design/steps-c/step-02-load-context.md
@@ -41,7 +41,7 @@ Load the required documents, config flags, and knowledge fragments needed to pro
 From `{config_source}`:
 
 - Read `tea_use_playwright_utils`
-- Note `output_folder`
+- Note `test_artifacts`
 
 ---
 

--- a/src/workflows/testarch/test-design/steps-c/step-05-generate-output.md
+++ b/src/workflows/testarch/test-design/steps-c/step-05-generate-output.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-05-generate-output'
 description: 'Generate output documents and validate against checklist'
-outputFile: '{output_folder}/test-design-epic-{epic_num}.md'
+outputFile: '{test_artifacts}/test-design-epic-{epic_num}.md'
 ---
 
 # Step 5: Generate Outputs & Validate
@@ -41,8 +41,8 @@ Write the final test-design document(s) using the correct template(s), then vali
 
 Generate **two** documents:
 
-- `{output_folder}/test-design-architecture.md` using `test-design-architecture-template.md`
-- `{output_folder}/test-design-qa.md` using `test-design-qa-template.md`
+- `{test_artifacts}/test-design-architecture.md` using `test-design-architecture-template.md`
+- `{test_artifacts}/test-design-qa.md` using `test-design-qa-template.md`
 
 ### Epic-Level Mode (Phase 4)
 

--- a/src/workflows/testarch/test-design/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/test-design/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{output_folder}/test-design-validation-report.md'
+outputFile: '{test_artifacts}/test-design-validation-report.md'
 validationChecklist: '../checklist.md'
 ---
 

--- a/src/workflows/testarch/test-design/test-design-qa-template.md
+++ b/src/workflows/testarch/test-design/test-design-qa-template.md
@@ -270,6 +270,19 @@ test('example test @p0', async ({ apiRequest }) => {
 
 ---
 
+## Sprint Planning Handoff (Optional)
+
+**Include only if this test design produces implementation tasks that must be scheduled.**
+
+**Use this to inform sprint planning; if no dedicated QA, assign to Dev owners.**
+
+| Work Item   | Owner        | Target Sprint (Optional) | Dependencies/Notes |
+| ----------- | ------------ | ------------------------ | ------------------ |
+| {Work item} | {QA/Dev/etc} | {Sprint or date}         | {Notes}            |
+| {Work item} | {QA/Dev/etc} | {Sprint or date}         | {Notes}            |
+
+---
+
 ## Tooling & Access
 
 **Include only if non-standard tools or access requests are required.**

--- a/src/workflows/testarch/test-design/workflow-plan.md
+++ b/src/workflows/testarch/test-design/workflow-plan.md
@@ -16,7 +16,7 @@
   - step-02-apply-edit.md
 
   ## Outputs
-  - {output_folder}/test-design-architecture.md (system-level)
+  - {test_artifacts}/test-design-architecture.md (system-level)
 
-- {output_folder}/test-design-qa.md (system-level)
-- {output_folder}/test-design-epic-{epic_num}.md (epic-level)
+- {test_artifacts}/test-design-qa.md (system-level)
+- {test_artifacts}/test-design-epic-{epic_num}.md (epic-level)

--- a/src/workflows/testarch/test-design/workflow.yaml
+++ b/src/workflows/testarch/test-design/workflow.yaml
@@ -6,6 +6,7 @@ author: "BMad"
 # Critical variables from config
 config_source: "{project-root}/_bmad/tea/config.yaml"
 output_folder: "{config_source}:output_folder"
+test_artifacts: "{config_source}:test_artifacts"
 user_name: "{config_source}:user_name"
 communication_language: "{config_source}:communication_language"
 document_output_language: "{config_source}:document_output_language"
@@ -32,20 +33,20 @@ outputs:
   # System-Level Mode (Phase 3) - TWO documents
   - id: test-design-architecture
     description: "System-level test architecture: Architectural concerns, testability gaps, NFR requirements for Architecture/Dev teams"
-    path: "{output_folder}/test-design-architecture.md"
+    path: "{test_artifacts}/test-design-architecture.md"
     mode: system-level
     audience: architecture
 
   - id: test-design-qa
     description: "System-level test design: Test execution recipe, coverage plan, Sprint 0 setup for QA team"
-    path: "{output_folder}/test-design-qa.md"
+    path: "{test_artifacts}/test-design-qa.md"
     mode: system-level
     audience: qa
 
   # Epic-Level Mode (Phase 4) - ONE document (unchanged)
   - id: epic-level
     description: "Epic-level test plan (Phase 4)"
-    path: "{output_folder}/test-design-epic-{epic_num}.md"
+    path: "{test_artifacts}/test-design-epic-{epic_num}.md"
     mode: epic-level
 # Note: No default_output_file - mode detection determines which outputs to write
 

--- a/src/workflows/testarch/test-review/instructions.md
+++ b/src/workflows/testarch/test-review/instructions.md
@@ -27,7 +27,7 @@ This workflow uses **step-file architecture**:
 
 From `workflow.yaml`, resolve:
 
-- `config_source`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `date`
+- `config_source`, `test_artifacts`, `user_name`, `communication_language`, `document_output_language`, `date`
 - `test_dir`, `review_scope`
 
 ### 2. First Step

--- a/src/workflows/testarch/test-review/steps-c/step-04-generate-report.md
+++ b/src/workflows/testarch/test-review/steps-c/step-04-generate-report.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-04-generate-report'
 description: 'Create test-review report and validate'
-outputFile: '{output_folder}/test-review.md'
+outputFile: '{test_artifacts}/test-review.md'
 ---
 
 # Step 4: Generate Report & Validate

--- a/src/workflows/testarch/test-review/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/test-review/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{output_folder}/test-review-validation-report.md'
+outputFile: '{test_artifacts}/test-review-validation-report.md'
 validationChecklist: '../checklist.md'
 ---
 

--- a/src/workflows/testarch/test-review/workflow-plan.md
+++ b/src/workflows/testarch/test-review/workflow-plan.md
@@ -15,4 +15,4 @@
   - step-02-apply-edit.md
 
   ## Outputs
-  - {output_folder}/test-review.md
+  - {test_artifacts}/test-review.md

--- a/src/workflows/testarch/test-review/workflow.yaml
+++ b/src/workflows/testarch/test-review/workflow.yaml
@@ -6,6 +6,7 @@ author: "BMad"
 # Critical variables from config
 config_source: "{project-root}/_bmad/tea/config.yaml"
 output_folder: "{config_source}:output_folder"
+test_artifacts: "{config_source}:test_artifacts"
 user_name: "{config_source}:user_name"
 communication_language: "{config_source}:communication_language"
 document_output_language: "{config_source}:document_output_language"
@@ -23,7 +24,7 @@ variables:
   review_scope: "single" # single (one file), directory (folder), suite (all tests)
 
 # Output configuration
-default_output_file: "{output_folder}/test-review.md"
+default_output_file: "{test_artifacts}/test-review.md"
 
 # Required tools
 required_tools:

--- a/src/workflows/testarch/trace/checklist.md
+++ b/src/workflows/testarch/trace/checklist.md
@@ -152,7 +152,7 @@ Knowledge fragments referenced:
 
 ### Traceability Matrix Markdown
 
-- [ ] File created at `{output_folder}/traceability-matrix.md`
+- [ ] File created at `{test_artifacts}/traceability-matrix.md`
 - [ ] Template from `trace-template.md` used
 - [ ] Full mapping table included
 - [ ] Coverage status section included
@@ -392,7 +392,7 @@ Knowledge fragments referenced:
 **Outputs Saved:**
 
 - [ ] Gate decision document saved to `{output_file}`
-- [ ] Gate YAML saved to `{output_folder}/gate-decision-{target}.yaml`
+- [ ] Gate YAML saved to `{test_artifacts}/gate-decision-{target}.yaml`
 - [ ] All outputs are valid and readable
 
 ---

--- a/src/workflows/testarch/trace/instructions.md
+++ b/src/workflows/testarch/trace/instructions.md
@@ -27,7 +27,7 @@ This workflow uses **step-file architecture**:
 
 From `workflow.yaml`, resolve:
 
-- `config_source`, `output_folder`, `user_name`, `communication_language`, `document_output_language`, `date`
+- `config_source`, `test_artifacts`, `user_name`, `communication_language`, `document_output_language`, `date`
 - `test_dir`, `source_dir`, `coverage_levels`, `gate_type`, `decision_mode`
 
 ### 2. First Step

--- a/src/workflows/testarch/trace/steps-c/step-05-gate-decision.md
+++ b/src/workflows/testarch/trace/steps-c/step-05-gate-decision.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-05-gate-decision'
 description: 'Phase 2: Apply gate decision logic and generate outputs'
-outputFile: '{output_folder}/traceability-report.md'
+outputFile: '{test_artifacts}/traceability-report.md'
 ---
 
 # Step 5: Phase 2 - Gate Decision

--- a/src/workflows/testarch/trace/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/trace/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{output_folder}/trace-validation-report.md'
+outputFile: '{test_artifacts}/trace-validation-report.md'
 validationChecklist: '../checklist.md'
 ---
 

--- a/src/workflows/testarch/trace/workflow-plan.md
+++ b/src/workflows/testarch/trace/workflow-plan.md
@@ -16,6 +16,6 @@
   - step-02-apply-edit.md
 
   ## Outputs
-  - {output_folder}/traceability-matrix.md
+  - {test_artifacts}/traceability-matrix.md
 
 - Gate decision summary (if evidence available)

--- a/src/workflows/testarch/trace/workflow.yaml
+++ b/src/workflows/testarch/trace/workflow.yaml
@@ -6,6 +6,7 @@ author: "BMad"
 # Critical variables from config
 config_source: "{project-root}/_bmad/tea/config.yaml"
 output_folder: "{config_source}:output_folder"
+test_artifacts: "{config_source}:test_artifacts"
 user_name: "{config_source}:user_name"
 communication_language: "{config_source}:communication_language"
 document_output_language: "{config_source}:document_output_language"
@@ -29,7 +30,7 @@ variables:
   decision_mode: "deterministic" # deterministic (rule-based) | manual (team decision)
 
 # Output configuration
-default_output_file: "{output_folder}/traceability-matrix.md"
+default_output_file: "{test_artifacts}/traceability-matrix.md"
 
 # Required tools
 required_tools:


### PR DESCRIPTION
###  test-design flexibility + sprint handoff
  - Make Project Team and Tooling & Access optional/less prescriptive in test-design templates
  - Add optional Sprint Planning Handoff section for schedulable QA/dev tasks
  - Align instructions/checklist wording and ordering guidance
closes https://github.com/bmad-code-org/bmad-method-test-architecture-enterprise/issues/17
  
### Artifacts output path fix
  - Route TEA workflow outputs to {test_artifacts} instead of {output_folder}
  - Add test_artifacts resolution in workflows and update output paths/checklists/plans
  - Clarify config docs for test_artifacts default and usage
closes https://github.com/bmad-code-org/bmad-method-test-architecture-enterprise/issues/16  
  