### PR TITLE
feat: trace with json output

### DIFF
--- a/src/workflows/testarch/bmad-testarch-trace/checklist.md
+++ b/src/workflows/testarch/bmad-testarch-trace/checklist.md
@@ -6,7 +6,7 @@
 This checklist covers **two sequential phases**:
 
 - **PHASE 1**: Requirements Traceability (always executed)
-- **PHASE 2**: Quality Gate Decision (executed if `enable_gate_decision: true`)
+- **PHASE 2**: Quality Gate Decision (decision fields emitted only when `allow_gate: true` and the collection is gate-eligible)
 
 ---
 
@@ -164,10 +164,25 @@ Knowledge fragments referenced:
 - [ ] Quality assessment section included
 - [ ] Recommendations section included
 
-### Coverage Badge/Metric (if enabled)
+### Machine-Readable JSON Output
 
-- [ ] Badge markdown generated
-- [ ] Metrics exported to JSON for CI/CD integration
+- [ ] `e2e-trace-summary.json` written to `{e2e_trace_summary_output}`
+- [ ] JSON is valid and parseable
+- [ ] `schema_version` field present
+- [ ] `repo`, `collection_mode`, `collection_status`, `coverage_basis`, and `source_sha` fields populated
+- [ ] `target.type` and `target.id` identify the evaluated story / epic / release / hotfix
+- [ ] `gate_status` populated only when `allow_gate: true` and `collection_status` is `COLLECTED`
+- [ ] `coverage_statistics` includes `priority_breakdown` (P0–P3) and `by_level` (e2e, api, component, unit)
+- [ ] `tests` counts are deduplicated from unique discovered tests (no per-requirement double counting)
+- [ ] `gap_analysis` counts match Phase 1 gap analysis
+- [ ] `heuristics` fields populated (`endpoint_gaps`, `auth_negative_path_status`, `error_path_status`)
+- [ ] `gate_criteria` thresholds and actuals match gate decision
+- [ ] `blockers` array present (may be empty)
+- [ ] `recommendations` array present (may be empty)
+- [ ] `links.trace_report_path` points to `traceability-matrix.md`
+- [ ] `links.trace_report_url` and `links.artifact_url` fields present (may be empty)
+- [ ] `gate-decision.json` written to `{gate_decision_output}` when gate-eligible
+- [ ] `gate-decision.json` contains `gate_status`, `rationale`, and per-criterion status fields
 
 ### Updated Story File (if enabled)
 
@@ -218,7 +233,7 @@ Knowledge fragments referenced:
 
 # PHASE 2: QUALITY GATE DECISION
 
-**Note**: Phase 2 executes only if `enable_gate_decision: true` in workflow.yaml
+**Note**: Phase 2 always emits `e2e-trace-summary.json`; gate decision fields are populated only when `allow_gate: true` and `collection_status` resolves to `COLLECTED`.
 
 ---
 
@@ -396,8 +411,9 @@ Knowledge fragments referenced:
 
 **Outputs Saved:**
 
-- [ ] Gate decision document saved to `{output_file}`
-- [ ] Gate YAML saved to `{test_artifacts}/gate-decision-{target}.yaml`
+- [ ] Gate decision document saved to `{outputFile}`
+- [ ] `e2e-trace-summary.json` saved to `{e2e_trace_summary_output}` (always)
+- [ ] `gate-decision.json` saved to `{gate_decision_output}` (when gate-eligible)
 - [ ] All outputs are valid and readable
 
 ---
@@ -595,7 +611,8 @@ Knowledge fragments referenced:
 - [ ] All quality evidence gathered
 - [ ] Decision criteria applied correctly
 - [ ] Decision rationale documented
-- [ ] Gate YAML ready for CI/CD integration
+- [ ] `e2e-trace-summary.json` written and valid JSON
+- [ ] `gate-decision.json` written when gate-eligible
 - [ ] Status file updated (if enabled)
 - [ ] Stakeholders notified (if enabled)
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-01-load-context.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-01-load-context.md
@@ -3,7 +3,7 @@ name: 'step-01-load-context'
 description: 'Load requirements, knowledge base, and related artifacts'
 nextStepFile: './step-02-discover-tests.md'
 knowledgeIndex: './resources/tea-index.csv'
-outputFile: '{test_artifacts}/traceability-report.md'
+outputFile: '{test_artifacts}/traceability-matrix.md'
 ---
 
 # Step 1: Load Context & Knowledge Base

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-01b-resume.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-01b-resume.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01b-resume'
 description: 'Resume interrupted workflow from last completed step'
-outputFile: '{test_artifacts}/traceability-report.md'
+outputFile: '{test_artifacts}/traceability-matrix.md'
 ---
 
 # Step 1b: Resume Workflow

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-02-discover-tests.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-02-discover-tests.md
@@ -2,7 +2,7 @@
 name: 'step-02-discover-tests'
 description: 'Discover and catalog tests by level'
 nextStepFile: './step-03-map-criteria.md'
-outputFile: '{test_artifacts}/traceability-report.md'
+outputFile: '{test_artifacts}/traceability-matrix.md'
 ---
 
 # Step 2: Discover & Catalog Tests
@@ -54,7 +54,11 @@ Classify as:
 - Component
 - Unit
 
-Record test IDs, describe blocks, and priority markers if present.
+Record test IDs, describe blocks, priority markers, and the per-test identity fields needed for machine-readable output:
+
+- Stable identity fields: `id`, `title`, `file`, `line`, `level`
+- Execution state flags: `skipped`, `pending`, `fixme`
+- Skip or blocker reason when it can be discovered from the test source or runtime metadata
 
 ---
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-03-map-criteria.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-03-map-criteria.md
@@ -2,7 +2,7 @@
 name: 'step-03-map-criteria'
 description: 'Map acceptance criteria to tests and build traceability matrix'
 nextStepFile: './step-04-analyze-gaps.md'
-outputFile: '{test_artifacts}/traceability-report.md'
+outputFile: '{test_artifacts}/traceability-matrix.md'
 ---
 
 # Step 3: Map Criteria to Tests
@@ -42,6 +42,7 @@ For each acceptance criterion:
 - Map to matching tests
 - Mark coverage status: FULL / PARTIAL / NONE / UNIT-ONLY / INTEGRATION-ONLY
 - Record test level and priority
+- Preserve each mapped test's stable identity fields (`id`, `title`, `file`, `line`, `level`, status flags) so Phase 1 can deduplicate unique tests before JSON export
 - Record heuristic signals:
   - Endpoint coverage present/missing (for API-impacting criteria)
   - Auth/authz coverage present/missing (positive and negative paths)

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-04-analyze-gaps.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-04-analyze-gaps.md
@@ -2,7 +2,7 @@
 name: 'step-04-analyze-gaps'
 description: 'Complete Phase 1 with adaptive orchestration (agent-team, subagent, or sequential)'
 nextStepFile: './step-05-gate-decision.md'
-outputFile: '{test_artifacts}/traceability-report.md'
+outputFile: '{test_artifacts}/traceability-matrix.md'
 tempOutputFile: '/tmp/tea-trace-coverage-matrix-{{timestamp}}.json'
 ---
 
@@ -253,6 +253,113 @@ const p3CoveragePercentage = safePct(p3Covered, p3Total);
 
 ---
 
+### 4b. Build Deduplicated Test Inventory and Trace Metadata
+
+Persist the unique discovered tests in Phase 1 so Step 5 does not need to reconstruct counts from per-requirement mappings.
+
+```javascript
+const coverageEligibleStatuses = new Set(['FULL', 'PARTIAL', 'UNIT-ONLY', 'INTEGRATION-ONLY']);
+const byLevel = {
+  e2e: { tests: 0, criteria_covered: 0 },
+  api: { tests: 0, criteria_covered: 0 },
+  component: { tests: 0, criteria_covered: 0 },
+  unit: { tests: 0, criteria_covered: 0 },
+};
+
+const normalizeTestStatus = (test) => {
+  const explicitStatus = String(test.status || '')
+    .trim()
+    .toLowerCase();
+  if (['skipped', 'pending', 'fixme'].includes(explicitStatus)) return explicitStatus;
+  if (test.fixme === true) return 'fixme';
+  if (test.pending === true) return 'pending';
+  if (test.skipped === true) return 'skipped';
+  return 'active';
+};
+
+const uniqueTests = new Map();
+(traceabilityMatrix || []).forEach((req) => {
+  (req.tests || []).forEach((test, index) => {
+    const stableId =
+      test.id ||
+      [test.file, test.title || test.name, test.line ?? index]
+        .filter((value) => value !== undefined && value !== null && value !== '')
+        .join(':') ||
+      `${req.id}:${index}`;
+
+    if (!uniqueTests.has(stableId)) {
+      const status = normalizeTestStatus(test);
+      uniqueTests.set(stableId, {
+        id: stableId,
+        file: test.file || '',
+        line: test.line ?? null,
+        title: test.title || test.name || stableId,
+        level: String(test.level || '')
+          .trim()
+          .toLowerCase(),
+        status: status,
+        skipped: status === 'skipped',
+        fixme: status === 'fixme',
+        pending: status === 'pending',
+        blocker_reason: test.skip_reason || test.blocker_reason || test.fixme_reason || test.pending_reason || '',
+      });
+    }
+  });
+});
+
+[...uniqueTests.values()].forEach((test) => {
+  if (byLevel[test.level]) byLevel[test.level].tests += 1;
+});
+
+(traceabilityMatrix || []).forEach((req) => {
+  if (!coverageEligibleStatuses.has(req.coverage)) return;
+  const requirementLevels = new Set(
+    (req.tests || [])
+      .map((test) =>
+        String(test.level || '')
+          .trim()
+          .toLowerCase(),
+      )
+      .filter((level) => byLevel[level]),
+  );
+  requirementLevels.forEach((level) => {
+    byLevel[level].criteria_covered += 1;
+  });
+});
+
+const deduplicatedTests = [...uniqueTests.values()];
+const deduplicatedTestInventory = {
+  summary: {
+    files: [...new Set(deduplicatedTests.map((test) => test.file).filter(Boolean))].length,
+    cases: deduplicatedTests.length,
+    skipped_cases: deduplicatedTests.filter((test) => test.skipped).length,
+    fixme_cases: deduplicatedTests.filter((test) => test.fixme).length,
+    pending_cases: deduplicatedTests.filter((test) => test.pending).length,
+    by_level: byLevel,
+  },
+  tests: deduplicatedTests,
+  blockers: deduplicatedTests
+    .filter((test) => ['skipped', 'pending', 'fixme'].includes(test.status))
+    .map((test) => ({
+      id: test.id,
+      severity: test.status === 'skipped' ? 'high' : 'medium',
+      reason: test.blocker_reason || `Test marked ${test.status} during trace collection`,
+      test_file: test.file,
+      test_title: test.title,
+    })),
+};
+
+const extractedTargetId = runtime.getTraceTargetId?.() || null;
+const extractedTargetLabel = runtime.getTraceTargetLabel?.() || null;
+const traceTarget = {
+  type: '{gate_type}',
+  id: extractedTargetId, // story_id / epic_num / release_version / hotfix identifier from Step 1
+  label: extractedTargetLabel || null,
+};
+```
+
+---
+
 ### 5. Generate Complete Coverage Matrix
 
 **Compile all Phase 1 outputs:**
@@ -261,6 +368,11 @@ const p3CoveragePercentage = safePct(p3Covered, p3Total);
 const coverageMatrix = {
   phase: 'PHASE_1_COMPLETE',
   generated_at: new Date().toISOString(),
+  trace_target: traceTarget,
+  collection_mode: '{collection_mode}',
+  allow_gate: '{allow_gate}',
+  coverage_basis: '{coverage_basis}',
+  summary_confidence: '{summary_confidence}',
 
   requirements: traceabilityMatrix, // Full matrix from Step 3
 
@@ -295,6 +407,8 @@ const coverageMatrix = {
     counts: heuristicGapCounts,
   },
 
+  test_inventory: deduplicatedTestInventory,
+  blockers: deduplicatedTestInventory.blockers,
   recommendations: recommendations,
 };
 ```
@@ -311,6 +425,16 @@ fs.writeFileSync(outputPath, JSON.stringify(coverageMatrix, null, 2), 'utf8');
 
 console.log(`✅ Phase 1 Complete: Coverage matrix saved to ${outputPath}`);
 ```
+
+**Record the resolved path in the progress document** so Step 5 can read the exact same file rather than re-evaluating the timestamp expression:
+
+After writing the temp file, update the YAML frontmatter in `{outputFile}` to include:
+
+```yaml
+tempCoverageMatrixPath: '<resolved outputPath>'
+```
+
+Step 5 reads `tempCoverageMatrixPath` from the frontmatter first; falls back to reconstructing `{tempOutputFile}` only when the key is absent.
 
 ---
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-04-analyze-gaps.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-04-analyze-gaps.md
@@ -264,6 +264,7 @@ const byLevel = {
   api: { tests: 0, criteria_covered: 0 },
   component: { tests: 0, criteria_covered: 0 },
   unit: { tests: 0, criteria_covered: 0 },
+  other: { tests: 0, criteria_covered: 0 }, // captures tests with unrecognized or empty level
 };
 
 const normalizeTestStatus = (test) => {
@@ -280,47 +281,50 @@ const normalizeTestStatus = (test) => {
 const uniqueTests = new Map();
 (traceabilityMatrix || []).forEach((req) => {
   (req.tests || []).forEach((test, index) => {
+    // Do NOT use the per-requirement `index` as a fallback — the same test can appear
+    // at different indices across requirements, producing spurious duplicate entries.
+    // Use only stable, test-intrinsic fields; omit line when unavailable.
     const stableId =
       test.id ||
-      [test.file, test.title || test.name, test.line ?? index]
-        .filter((value) => value !== undefined && value !== null && value !== '')
-        .join(':') ||
-      `${req.id}:${index}`;
+      [test.file, test.title || test.name, test.line].filter((value) => value !== undefined && value !== null && value !== '').join(':') ||
+      null; // unresolvable — skip rather than manufacture a key
 
-    if (!uniqueTests.has(stableId)) {
-      const status = normalizeTestStatus(test);
-      uniqueTests.set(stableId, {
-        id: stableId,
-        file: test.file || '',
-        line: test.line ?? null,
-        title: test.title || test.name || stableId,
-        level: String(test.level || '')
-          .trim()
-          .toLowerCase(),
-        status: status,
-        skipped: status === 'skipped',
-        fixme: status === 'fixme',
-        pending: status === 'pending',
-        blocker_reason: test.skip_reason || test.blocker_reason || test.fixme_reason || test.pending_reason || '',
-      });
-    }
+    if (stableId === null || uniqueTests.has(stableId)) return;
+    const status = normalizeTestStatus(test);
+    uniqueTests.set(stableId, {
+      id: stableId,
+      file: test.file || '',
+      line: test.line ?? null,
+      title: test.title || test.name || stableId,
+      level: String(test.level || '')
+        .trim()
+        .toLowerCase(),
+      status: status,
+      skipped: status === 'skipped',
+      fixme: status === 'fixme',
+      pending: status === 'pending',
+      blocker_reason: test.skip_reason || test.blocker_reason || test.fixme_reason || test.pending_reason || '',
+    });
   });
 });
 
 [...uniqueTests.values()].forEach((test) => {
-  if (byLevel[test.level]) byLevel[test.level].tests += 1;
+  const bucket = byLevel[test.level] ? test.level : 'other';
+  if (bucket === 'other' && test.level) {
+    console.warn(`[trace] unknown test level "${test.level}" for test "${test.id}" — counted in "other"`);
+  }
+  byLevel[bucket].tests += 1;
 });
 
 (traceabilityMatrix || []).forEach((req) => {
   if (!coverageEligibleStatuses.has(req.coverage)) return;
   const requirementLevels = new Set(
-    (req.tests || [])
-      .map((test) =>
-        String(test.level || '')
-          .trim()
-          .toLowerCase(),
-      )
-      .filter((level) => byLevel[level]),
+    (req.tests || []).map((test) => {
+      const level = String(test.level || '')
+        .trim()
+        .toLowerCase();
+      return byLevel[level] ? level : 'other';
+    }),
   );
   requirementLevels.forEach((level) => {
     byLevel[level].criteria_covered += 1;

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-05-gate-decision.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-05-gate-decision.md
@@ -1,14 +1,14 @@
 ---
 name: 'step-05-gate-decision'
 description: 'Phase 2: Apply gate decision logic and generate outputs'
-outputFile: '{test_artifacts}/traceability-report.md'
+outputFile: '{test_artifacts}/traceability-matrix.md'
 ---
 
 # Step 5: Phase 2 - Gate Decision
 
 ## STEP GOAL
 
-**Phase 2:** Read coverage matrix from Phase 1, apply deterministic gate decision logic, and generate traceability report.
+**Phase 2:** Read coverage matrix from Phase 1, apply deterministic gate decision logic when gate-eligible, and generate the traceability report plus machine-readable outputs.
 
 ---
 
@@ -17,7 +17,7 @@ outputFile: '{test_artifacts}/traceability-report.md'
 - 📖 Read the entire step file before acting
 - ✅ Speak in `{communication_language}`
 - ✅ Read coverage matrix from Phase 1 temp file
-- ✅ Apply gate decision logic
+- ✅ Resolve collection status and gate eligibility before applying gate decision logic
 - ❌ Do NOT regenerate coverage matrix (use Phase 1 output)
 
 ---
@@ -40,8 +40,14 @@ outputFile: '{test_artifacts}/traceability-report.md'
 
 ### 1. Read Phase 1 Coverage Matrix
 
+Read `{outputFile}` frontmatter for `tempCoverageMatrixPath`. Use it when present; fall back to the templated path only when absent:
+
 ```javascript
-const matrixPath = '/tmp/tea-trace-coverage-matrix-{{timestamp}}.json';
+const progressDoc = fs.readFileSync('{outputFile}', 'utf8');
+const frontmatterMatch = progressDoc.match(/^---\n([\s\S]*?)\n---/);
+const frontmatter = frontmatterMatch ? yaml.parse(frontmatterMatch[1]) : {};
+
+const matrixPath = frontmatter.tempCoverageMatrixPath || '/tmp/tea-trace-coverage-matrix-{{timestamp}}.json';
 const coverageMatrix = JSON.parse(fs.readFileSync(matrixPath, 'utf8'));
 
 console.log('✅ Phase 1 coverage matrix loaded');
@@ -70,46 +76,71 @@ const effectiveP1Coverage = hasP1Requirements ? p1Coverage : 100;
 const overallCoverage = stats.overall_coverage_percentage;
 const criticalGaps = coverageMatrix.gap_analysis.critical_gaps.length;
 
+const normalizeBoolean = (value, defaultValue = true) => {
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['false', '0', 'off', 'no'].includes(normalized)) return false;
+    if (['true', '1', 'on', 'yes'].includes(normalized)) return true;
+  }
+  if (value === undefined || value === null) return defaultValue;
+  return Boolean(value);
+};
+
+const collectionMode = String(coverageMatrix.collection_mode || '{collection_mode}' || 'contract_static')
+  .trim()
+  .toLowerCase();
+const allowGate = normalizeBoolean(coverageMatrix.allow_gate ?? '{allow_gate}', true);
+const collectionStatus =
+  coverageMatrix.collection_status ||
+  {
+    waived: 'WAIVED',
+    restricted: 'RESTRICTED',
+    inaccessible: 'INACCESSIBLE',
+    deferred_shared: 'DEFERRED_SHARED',
+  }[collectionMode] ||
+  'COLLECTED';
+const gateEligible = allowGate && collectionStatus === 'COLLECTED';
+
 let gateDecision;
 let rationale;
 
-// Rule 1: P0 coverage must be 100%
-if (p0Coverage < 100) {
-  gateDecision = 'FAIL';
-  rationale = `P0 coverage is ${p0Coverage}% (required: 100%). ${criticalGaps} critical requirements uncovered.`;
-}
-// Rule 2: Overall coverage must be >= 80%
-else if (overallCoverage < 80) {
-  gateDecision = 'FAIL';
-  rationale = `Overall coverage is ${overallCoverage}% (minimum: 80%). Significant gaps exist.`;
-}
-// Rule 3: P1 coverage < 80% → FAIL
-else if (effectiveP1Coverage < 80) {
-  gateDecision = 'FAIL';
-  rationale = hasP1Requirements
-    ? `P1 coverage is ${effectiveP1Coverage}% (minimum: 80%). High-priority gaps must be addressed.`
-    : `P1 requirements are not present; continuing with remaining gate criteria.`;
-}
-// Rule 4: P1 coverage >= 90% and overall >= 80% with P0 at 100% → PASS
-else if (effectiveP1Coverage >= 90) {
-  gateDecision = 'PASS';
-  rationale = hasP1Requirements
-    ? `P0 coverage is 100%, P1 coverage is ${effectiveP1Coverage}% (target: 90%), and overall coverage is ${overallCoverage}% (minimum: 80%).`
-    : `P0 coverage is 100% and overall coverage is ${overallCoverage}% (minimum: 80%). No P1 requirements detected.`;
-}
-// Rule 5: P1 coverage 80-89% with P0 at 100% and overall >= 80% → CONCERNS
-else if (effectiveP1Coverage >= 80) {
-  gateDecision = 'CONCERNS';
-  rationale = hasP1Requirements
-    ? `P0 coverage is 100% and overall coverage is ${overallCoverage}% (minimum: 80%), but P1 coverage is ${effectiveP1Coverage}% (target: 90%).`
-    : `P0 coverage is 100% and overall coverage is ${overallCoverage}% (minimum: 80%), but additional non-P1 gaps need mitigation.`;
-}
+if (!gateEligible) {
+  rationale = `Gate decision skipped because allow_gate=${allowGate} and collection_status=${collectionStatus}.`;
+} else {
+  // Rule 1: P0 coverage must be 100%
+  if (p0Coverage < 100) {
+    gateDecision = 'FAIL';
+    rationale = `P0 coverage is ${p0Coverage}% (required: 100%). ${criticalGaps} critical requirements uncovered.`;
+  }
+  // Rule 2: Overall coverage must be >= 80%
+  else if (overallCoverage < 80) {
+    gateDecision = 'FAIL';
+    rationale = `Overall coverage is ${overallCoverage}% (minimum: 80%). Significant gaps exist.`;
+  }
+  // Rule 3: P1 coverage < 80% → FAIL
+  else if (effectiveP1Coverage < 80) {
+    gateDecision = 'FAIL';
+    rationale = hasP1Requirements
+      ? `P1 coverage is ${effectiveP1Coverage}% (minimum: 80%). High-priority gaps must be addressed.`
+      : `P1 requirements are not present; continuing with remaining gate criteria.`;
+  }
+  // Rule 4: P1 coverage >= 90% and overall >= 80% with P0 at 100% → PASS
+  else if (effectiveP1Coverage >= 90) {
+    gateDecision = 'PASS';
+    rationale = hasP1Requirements
+      ? `P0 coverage is 100%, P1 coverage is ${effectiveP1Coverage}% (target: 90%), and overall coverage is ${overallCoverage}% (minimum: 80%).`
+      : `P0 coverage is 100% and overall coverage is ${overallCoverage}% (minimum: 80%). No P1 requirements detected.`;
+  }
+  // Rule 5: P1 coverage 80-89% with P0 at 100% and overall >= 80% → CONCERNS
+  else if (effectiveP1Coverage >= 80) {
+    gateDecision = 'CONCERNS';
+    rationale = hasP1Requirements
+      ? `P0 coverage is 100% and overall coverage is ${overallCoverage}% (minimum: 80%), but P1 coverage is ${effectiveP1Coverage}% (target: 90%).`
+      : `P0 coverage is 100% and overall coverage is ${overallCoverage}% (minimum: 80%), but additional non-P1 gaps need mitigation.`;
+  }
 
-// Rule 6: Manual waiver option
-const manualWaiver = false; // Can be set via config or user input
-if (manualWaiver) {
-  gateDecision = 'WAIVED';
-  rationale += ' Manual waiver applied by stakeholder.';
+  // Rule 6: Manual waiver — set gateDecision = 'WAIVED' and update rationale here
+  // if a stakeholder-approved waiver applies (wired through config or user input upstream).
 }
 ```
 
@@ -119,31 +150,267 @@ if (manualWaiver) {
 
 ```javascript
 const gateReport = {
-  decision: gateDecision,
+  gate_eligible: gateEligible,
+  collection_status: collectionStatus,
+  decision: gateEligible ? gateDecision : 'NOT_EVALUATED',
   rationale: rationale,
   decision_date: new Date().toISOString(),
 
   coverage_matrix: coverageMatrix,
 
-  gate_criteria: {
-    p0_coverage_required: '100%',
-    p0_coverage_actual: `${p0Coverage}%`,
-    p0_status: p0Coverage === 100 ? 'MET' : 'NOT MET',
+  gate_criteria: gateEligible
+    ? {
+        p0_coverage_required: '100%',
+        p0_coverage_actual: `${p0Coverage}%`,
+        p0_status: p0Coverage === 100 ? 'MET' : 'NOT_MET',
 
-    p1_coverage_target_pass: '90%',
-    p1_coverage_minimum: '80%',
-    p1_coverage_actual: `${effectiveP1Coverage}%`,
-    p1_status: effectiveP1Coverage >= 90 ? 'MET' : effectiveP1Coverage >= 80 ? 'PARTIAL' : 'NOT MET',
+        p1_coverage_target_pass: '90%',
+        p1_coverage_minimum: '80%',
+        p1_coverage_actual: `${effectiveP1Coverage}%`,
+        p1_status: effectiveP1Coverage >= 90 ? 'MET' : effectiveP1Coverage >= 80 ? 'PARTIAL' : 'NOT_MET',
 
-    overall_coverage_minimum: '80%',
-    overall_coverage_actual: `${overallCoverage}%`,
-    overall_status: overallCoverage >= 80 ? 'MET' : 'NOT MET',
-  },
+        overall_coverage_minimum: '80%',
+        overall_coverage_actual: `${overallCoverage}%`,
+        overall_status: overallCoverage >= 80 ? 'MET' : 'NOT_MET',
+      }
+    : null,
 
   uncovered_requirements: coverageMatrix.gap_analysis.critical_gaps.concat(coverageMatrix.gap_analysis.high_gaps),
 
   recommendations: coverageMatrix.recommendations,
 };
+```
+
+---
+
+### 3b. Emit `e2e-trace-summary.json`
+
+**After the gate report is assembled, write the machine-readable summary to `{e2e_trace_summary_output}`.**
+
+This file is the portable, automation-friendly companion to the markdown report. Any CI/CD pipeline, reporting dashboard, or LLM agent can consume it without parsing markdown.
+
+```javascript
+const buildFallbackInventory = () => {
+  const byLevel = {
+    e2e: { tests: 0, criteria_covered: 0 },
+    api: { tests: 0, criteria_covered: 0 },
+    component: { tests: 0, criteria_covered: 0 },
+    unit: { tests: 0, criteria_covered: 0 },
+  };
+  const coverageEligibleStatuses = new Set(['FULL', 'PARTIAL', 'UNIT-ONLY', 'INTEGRATION-ONLY']);
+  const uniqueTests = new Map();
+
+  (coverageMatrix.requirements || []).forEach((req) => {
+    (req.tests || []).forEach((test, index) => {
+      const stableId =
+        test.id ||
+        [test.file, test.title || test.name, test.line ?? index]
+          .filter((value) => value !== undefined && value !== null && value !== '')
+          .join(':') ||
+        `${req.id}:${index}`;
+
+      if (!uniqueTests.has(stableId)) {
+        const explicitStatus = String(test.status || '')
+          .trim()
+          .toLowerCase();
+        const status = ['skipped', 'pending', 'fixme'].includes(explicitStatus)
+          ? explicitStatus
+          : test.fixme === true
+            ? 'fixme'
+            : test.pending === true
+              ? 'pending'
+              : test.skipped === true
+                ? 'skipped'
+                : 'active';
+
+        uniqueTests.set(stableId, {
+          id: stableId,
+          file: test.file || '',
+          title: test.title || test.name || stableId,
+          level: String(test.level || '')
+            .trim()
+            .toLowerCase(),
+          skipped: status === 'skipped',
+          fixme: status === 'fixme',
+          pending: status === 'pending',
+          status: status,
+          blocker_reason: test.skip_reason || test.blocker_reason || test.fixme_reason || test.pending_reason || '',
+        });
+      }
+    });
+
+    if (!coverageEligibleStatuses.has(req.coverage)) return;
+    const requirementLevels = new Set(
+      (req.tests || [])
+        .map((test) =>
+          String(test.level || '')
+            .trim()
+            .toLowerCase(),
+        )
+        .filter((level) => byLevel[level]),
+    );
+    requirementLevels.forEach((level) => {
+      byLevel[level].criteria_covered += 1;
+    });
+  });
+
+  const deduplicatedTests = [...uniqueTests.values()];
+  deduplicatedTests.forEach((test) => {
+    if (byLevel[test.level]) byLevel[test.level].tests += 1;
+  });
+
+  return {
+    summary: {
+      files: [...new Set(deduplicatedTests.map((test) => test.file).filter(Boolean))].length,
+      cases: deduplicatedTests.length,
+      skipped_cases: deduplicatedTests.filter((test) => test.skipped).length,
+      fixme_cases: deduplicatedTests.filter((test) => test.fixme).length,
+      pending_cases: deduplicatedTests.filter((test) => test.pending).length,
+      by_level: byLevel,
+    },
+    blockers: deduplicatedTests
+      .filter((test) => ['skipped', 'pending', 'fixme'].includes(test.status))
+      .map((test) => ({
+        id: test.id,
+        severity: test.status === 'skipped' ? 'high' : 'medium',
+        reason: test.blocker_reason || `Test marked ${test.status} during trace collection`,
+        test_file: test.file,
+        test_title: test.title,
+      })),
+  };
+};
+
+const fallbackInventory = buildFallbackInventory();
+const testInventory = coverageMatrix.test_inventory?.summary || fallbackInventory.summary;
+const blockers = coverageMatrix.blockers || coverageMatrix.test_inventory?.blockers || fallbackInventory.blockers;
+
+const heuristicCounts = coverageMatrix.coverage_heuristics?.counts || {};
+const endpointGapCount = heuristicCounts.endpoints_without_tests ?? 0;
+const authGapCount = heuristicCounts.auth_missing_negative_paths ?? 0;
+const errorPathGapCount = heuristicCounts.happy_path_only_criteria ?? 0;
+const sourceSha = process.env.GITHUB_SHA || runtime.getSourceSha?.() || '';
+
+const e2eTraceSummary = {
+  schema_version: 1,
+  generated_at: new Date().toISOString(),
+  workflow: 'bmad-testarch-trace',
+  repo: '{project_name}',
+  collection_mode: collectionMode,
+  collection_status: collectionStatus,
+  coverage_basis: coverageMatrix.coverage_basis || '{coverage_basis}',
+  source_sha: sourceSha,
+  gate_eligible: gateEligible,
+  target: coverageMatrix.trace_target || { type: '{gate_type}', id: null, label: null },
+  decision_mode: '{decision_mode}',
+  evaluator: '{user_name}',
+  confidence: coverageMatrix.summary_confidence || '{summary_confidence}',
+
+  coverage_statistics: {
+    total_requirements: stats.total_requirements,
+    fully_covered: stats.fully_covered,
+    partially_covered: stats.partially_covered ?? coverageMatrix.gap_analysis?.partial_coverage_items?.length ?? 0,
+    uncovered: stats.uncovered ?? 0,
+    overall_coverage_pct: stats.overall_coverage_percentage,
+    priority_breakdown: {
+      P0: {
+        total: stats.priority_breakdown.P0.total,
+        covered: stats.priority_breakdown.P0.covered,
+        pct: stats.priority_breakdown.P0.percentage,
+      },
+      P1: {
+        total: stats.priority_breakdown.P1.total,
+        covered: stats.priority_breakdown.P1.covered,
+        pct: stats.priority_breakdown.P1.percentage,
+      },
+      P2: {
+        total: stats.priority_breakdown.P2.total,
+        covered: stats.priority_breakdown.P2.covered,
+        pct: stats.priority_breakdown.P2.percentage,
+      },
+      P3: {
+        total: stats.priority_breakdown.P3.total,
+        covered: stats.priority_breakdown.P3.covered,
+        pct: stats.priority_breakdown.P3.percentage,
+      },
+    },
+    by_level: testInventory.by_level,
+  },
+
+  tests: {
+    files: testInventory.files || 0,
+    cases: testInventory.cases || 0,
+    skipped_cases: testInventory.skipped_cases || 0,
+    fixme_cases: testInventory.fixme_cases || 0,
+    pending_cases: testInventory.pending_cases || 0,
+  },
+
+  gap_analysis: {
+    critical_gaps: coverageMatrix.gap_analysis.critical_gaps.length,
+    high_gaps: coverageMatrix.gap_analysis.high_gaps.length,
+    medium_gaps: coverageMatrix.gap_analysis.medium_gaps.length,
+    low_gaps: coverageMatrix.gap_analysis.low_gaps.length,
+  },
+
+  heuristics: {
+    endpoint_gaps: endpointGapCount,
+    auth_negative_path_status: authGapCount === 0 ? 'present' : authGapCount <= 2 ? 'partial' : 'none',
+    error_path_status: errorPathGapCount === 0 ? 'present' : errorPathGapCount <= 2 ? 'partial' : 'none',
+  },
+
+  blockers: blockers,
+  recommendations: coverageMatrix.recommendations,
+
+  links: {
+    trace_report_path: '{outputFile}',
+    trace_report_url: '', // populated by CI/CD runner after artifact upload
+    artifact_url: '',
+  },
+};
+
+if (gateEligible) {
+  e2eTraceSummary.gate_status = gateDecision;
+  e2eTraceSummary.gate_criteria = {
+    p0_coverage_required: '100%',
+    p0_coverage_actual: `${p0Coverage}%`,
+    p0_status: p0Coverage === 100 ? 'MET' : 'NOT_MET',
+    p1_coverage_target: '90%',
+    p1_coverage_minimum: '80%',
+    p1_coverage_actual: `${effectiveP1Coverage}%`,
+    p1_status: effectiveP1Coverage >= 90 ? 'MET' : effectiveP1Coverage >= 80 ? 'PARTIAL' : 'NOT_MET',
+    overall_coverage_minimum: '80%',
+    overall_coverage_actual: `${overallCoverage}%`,
+    overall_status: overallCoverage >= 80 ? 'MET' : 'NOT_MET',
+  };
+}
+
+fs.writeFileSync('{e2e_trace_summary_output}', JSON.stringify(e2eTraceSummary, null, 2), 'utf8');
+console.log(`✅ e2e-trace-summary.json written to {e2e_trace_summary_output}`);
+```
+
+**Optional: emit `gate-decision.json`** for pipelines that only need the gate signal without the full summary:
+
+```javascript
+// Construct and write only when gate evaluation was performed and produced a meaningful decision.
+// gateDecisionSlim is intentionally inside this guard: e2eTraceSummary.gate_criteria is only
+// populated when gateEligible is true, so constructing it outside would throw when !gateEligible.
+if (gateEligible && ['PASS', 'CONCERNS', 'FAIL', 'WAIVED'].includes(gateDecision)) {
+  const gateDecisionSlim = {
+    schema_version: 1,
+    generated_at: e2eTraceSummary.generated_at,
+    repo: e2eTraceSummary.repo,
+    target: e2eTraceSummary.target,
+    collection_status: e2eTraceSummary.collection_status,
+    gate_status: gateDecision,
+    rationale: rationale,
+    p0_status: e2eTraceSummary.gate_criteria.p0_status,
+    p1_status: e2eTraceSummary.gate_criteria.p1_status,
+    overall_status: e2eTraceSummary.gate_criteria.overall_status,
+    critical_gaps: e2eTraceSummary.gap_analysis.critical_gaps,
+    links: e2eTraceSummary.links,
+  };
+  fs.writeFileSync('{gate_decision_output}', JSON.stringify(gateDecisionSlim, null, 2), 'utf8');
+  console.log(`✅ gate-decision.json written to {gate_decision_output}`);
+}
 ```
 
 ---
@@ -206,6 +473,10 @@ fs.writeFileSync('{outputFile}', reportContent, 'utf8');
 
 📂 Full Report: {outputFile}
 
+{if !gateEligible}
+ℹ️ GATE: NOT EVALUATED - collection status is {collectionStatus}; machine-readable summary still emitted
+{endif}
+
 {if FAIL}
 🚫 GATE: FAIL - Release BLOCKED until coverage improves
 {endif}
@@ -240,7 +511,9 @@ Then append the gate decision summary (from section 5 above) to the end of the e
 **WORKFLOW COMPLETE when:**
 
 - ✅ Phase 1 coverage matrix read successfully
-- ✅ Gate decision logic applied
+- ✅ Collection status resolved and gate decision logic applied when eligible
+- ✅ `e2e-trace-summary.json` written to `{e2e_trace_summary_output}`
+- ✅ `gate-decision.json` written to `{gate_decision_output}` (when gate-eligible)
 - ✅ Traceability report generated
 - ✅ Gate decision displayed
 
@@ -253,14 +526,17 @@ Then append the gate decision summary (from section 5 above) to the end of the e
 ### ✅ SUCCESS:
 
 - Coverage matrix read from Phase 1
-- Gate decision made with clear rationale
+- Gate decision made with clear rationale when gate-eligible
+- `e2e-trace-summary.json` written and valid
+- `gate-decision.json` written when gate-eligible
 - Report generated and saved
 - Decision communicated clearly
 
 ### ❌ FAILURE:
 
 - Could not read Phase 1 matrix
-- Gate decision logic incorrect
+- Gate eligibility or gate decision logic incorrect
+- `e2e-trace-summary.json` missing or invalid JSON
 - Report missing or incomplete
 
-**Master Rule:** Gate decision MUST be deterministic based on clear criteria (P0 100%, P1 90/80, overall >=80).
+**Master Rule:** Gate decision MUST be deterministic based on clear criteria (P0 100%, P1 90/80, overall >=80) whenever `allow_gate` is true and `collection_status` is `COLLECTED`. `e2e-trace-summary.json` MUST be written before the workflow terminates.

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-05-gate-decision.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-05-gate-decision.md
@@ -40,14 +40,20 @@ outputFile: '{test_artifacts}/traceability-matrix.md'
 
 ### 1. Read Phase 1 Coverage Matrix
 
-Read `{outputFile}` frontmatter for `tempCoverageMatrixPath`. Use it when present; fall back to the templated path only when absent:
+Read `{outputFile}` frontmatter for `tempCoverageMatrixPath`. Halt when missing — the fallback timestamp cannot be reconstructed reliably in a different execution context:
 
 ```javascript
 const progressDoc = fs.readFileSync('{outputFile}', 'utf8');
 const frontmatterMatch = progressDoc.match(/^---\n([\s\S]*?)\n---/);
 const frontmatter = frontmatterMatch ? yaml.parse(frontmatterMatch[1]) : {};
 
-const matrixPath = frontmatter.tempCoverageMatrixPath || '/tmp/tea-trace-coverage-matrix-{{timestamp}}.json';
+const matrixPath = frontmatter.tempCoverageMatrixPath;
+if (!matrixPath) {
+  throw new Error(
+    '❌ tempCoverageMatrixPath not found in progress frontmatter. ' +
+      'Step 4 must record the resolved temp file path before Step 5 can proceed.',
+  );
+}
 const coverageMatrix = JSON.parse(fs.readFileSync(matrixPath, 'utf8'));
 
 console.log('✅ Phase 1 coverage matrix loaded');
@@ -86,11 +92,13 @@ const normalizeBoolean = (value, defaultValue = true) => {
   return Boolean(value);
 };
 
-const collectionMode = String(coverageMatrix.collection_mode || '{collection_mode}' || 'contract_static')
+const isUnresolved = (v) => typeof v === 'string' && v.startsWith('{') && v.endsWith('}');
+const collectionMode = String(!isUnresolved(coverageMatrix.collection_mode) ? coverageMatrix.collection_mode : 'contract_static')
   .trim()
   .toLowerCase();
-const allowGate = normalizeBoolean(coverageMatrix.allow_gate ?? '{allow_gate}', true);
-const collectionStatus =
+const rawAllowGate = !isUnresolved(coverageMatrix.allow_gate) ? coverageMatrix.allow_gate : true;
+const allowGate = normalizeBoolean(rawAllowGate, true);
+const rawCollectionStatus =
   coverageMatrix.collection_status ||
   {
     waived: 'WAIVED',
@@ -99,9 +107,11 @@ const collectionStatus =
     deferred_shared: 'DEFERRED_SHARED',
   }[collectionMode] ||
   'COLLECTED';
+// Normalize to UPPER_CASE + trimmed so comparisons are whitespace/case-safe.
+const collectionStatus = String(rawCollectionStatus).trim().toUpperCase();
 const gateEligible = allowGate && collectionStatus === 'COLLECTED';
 
-let gateDecision;
+let gateDecision = 'NOT_EVALUATED'; // default; overwritten when gateEligible
 let rationale;
 
 if (!gateEligible) {
@@ -164,7 +174,7 @@ const gateReport = {
         p0_coverage_actual: `${p0Coverage}%`,
         p0_status: p0Coverage === 100 ? 'MET' : 'NOT_MET',
 
-        p1_coverage_target_pass: '90%',
+        p1_coverage_target: '90%',
         p1_coverage_minimum: '80%',
         p1_coverage_actual: `${effectiveP1Coverage}%`,
         p1_status: effectiveP1Coverage >= 90 ? 'MET' : effectiveP1Coverage >= 80 ? 'PARTIAL' : 'NOT_MET',
@@ -196,58 +206,57 @@ const buildFallbackInventory = () => {
     api: { tests: 0, criteria_covered: 0 },
     component: { tests: 0, criteria_covered: 0 },
     unit: { tests: 0, criteria_covered: 0 },
+    other: { tests: 0, criteria_covered: 0 }, // captures tests with unrecognized or empty level
   };
   const coverageEligibleStatuses = new Set(['FULL', 'PARTIAL', 'UNIT-ONLY', 'INTEGRATION-ONLY']);
   const uniqueTests = new Map();
 
   (coverageMatrix.requirements || []).forEach((req) => {
-    (req.tests || []).forEach((test, index) => {
+    (req.tests || []).forEach((test) => {
       const stableId =
         test.id ||
-        [test.file, test.title || test.name, test.line ?? index]
+        [test.file, test.title || test.name, test.line]
           .filter((value) => value !== undefined && value !== null && value !== '')
           .join(':') ||
-        `${req.id}:${index}`;
+        null; // unresolvable — skip rather than manufacture a key
 
-      if (!uniqueTests.has(stableId)) {
-        const explicitStatus = String(test.status || '')
+      if (stableId === null || uniqueTests.has(stableId)) return;
+      const explicitStatus = String(test.status || '')
+        .trim()
+        .toLowerCase();
+      const status = ['skipped', 'pending', 'fixme'].includes(explicitStatus)
+        ? explicitStatus
+        : test.fixme === true
+          ? 'fixme'
+          : test.pending === true
+            ? 'pending'
+            : test.skipped === true
+              ? 'skipped'
+              : 'active';
+
+      uniqueTests.set(stableId, {
+        id: stableId,
+        file: test.file || '',
+        title: test.title || test.name || stableId,
+        level: String(test.level || '')
           .trim()
-          .toLowerCase();
-        const status = ['skipped', 'pending', 'fixme'].includes(explicitStatus)
-          ? explicitStatus
-          : test.fixme === true
-            ? 'fixme'
-            : test.pending === true
-              ? 'pending'
-              : test.skipped === true
-                ? 'skipped'
-                : 'active';
-
-        uniqueTests.set(stableId, {
-          id: stableId,
-          file: test.file || '',
-          title: test.title || test.name || stableId,
-          level: String(test.level || '')
-            .trim()
-            .toLowerCase(),
-          skipped: status === 'skipped',
-          fixme: status === 'fixme',
-          pending: status === 'pending',
-          status: status,
-          blocker_reason: test.skip_reason || test.blocker_reason || test.fixme_reason || test.pending_reason || '',
-        });
-      }
+          .toLowerCase(),
+        skipped: status === 'skipped',
+        fixme: status === 'fixme',
+        pending: status === 'pending',
+        status: status,
+        blocker_reason: test.skip_reason || test.blocker_reason || test.fixme_reason || test.pending_reason || '',
+      });
     });
 
     if (!coverageEligibleStatuses.has(req.coverage)) return;
     const requirementLevels = new Set(
-      (req.tests || [])
-        .map((test) =>
-          String(test.level || '')
-            .trim()
-            .toLowerCase(),
-        )
-        .filter((level) => byLevel[level]),
+      (req.tests || []).map((test) => {
+        const level = String(test.level || '')
+          .trim()
+          .toLowerCase();
+        return byLevel[level] ? level : 'other';
+      }),
     );
     requirementLevels.forEach((level) => {
       byLevel[level].criteria_covered += 1;
@@ -256,7 +265,8 @@ const buildFallbackInventory = () => {
 
   const deduplicatedTests = [...uniqueTests.values()];
   deduplicatedTests.forEach((test) => {
-    if (byLevel[test.level]) byLevel[test.level].tests += 1;
+    const bucket = byLevel[test.level] ? test.level : 'other';
+    byLevel[bucket].tests += 1;
   });
 
   return {
@@ -345,10 +355,10 @@ const e2eTraceSummary = {
   },
 
   gap_analysis: {
-    critical_gaps: coverageMatrix.gap_analysis.critical_gaps.length,
-    high_gaps: coverageMatrix.gap_analysis.high_gaps.length,
-    medium_gaps: coverageMatrix.gap_analysis.medium_gaps.length,
-    low_gaps: coverageMatrix.gap_analysis.low_gaps.length,
+    critical_gaps: (coverageMatrix.gap_analysis?.critical_gaps || []).length,
+    high_gaps: (coverageMatrix.gap_analysis?.high_gaps || []).length,
+    medium_gaps: (coverageMatrix.gap_analysis?.medium_gaps || []).length,
+    low_gaps: (coverageMatrix.gap_analysis?.low_gaps || []).length,
   },
 
   heuristics: {

--- a/src/workflows/testarch/bmad-testarch-trace/workflow-plan.md
+++ b/src/workflows/testarch/bmad-testarch-trace/workflow-plan.md
@@ -1,21 +1,24 @@
-    # Workflow Plan: testarch-trace
+# Workflow Plan: testarch-trace
 
-    ## Create Mode (steps-c)
-    - step-01-load-context.md
+## Create Mode (steps-c)
 
+- step-01-load-context.md
 - step-02-discover-tests.md
 - step-03-map-criteria.md
 - step-04-analyze-gaps.md
 - step-05-gate-decision.md
 
-  ## Validate Mode (steps-v)
-  - step-01-validate.md
+## Validate Mode (steps-v)
 
-  ## Edit Mode (steps-e)
-  - step-01-assess.md
-  - step-02-apply-edit.md
+- step-01-validate.md
 
-  ## Outputs
-  - {test_artifacts}/traceability-matrix.md
+## Edit Mode (steps-e)
 
-- Gate decision summary (if evidence available)
+- step-01-assess.md
+- step-02-apply-edit.md
+
+## Outputs
+
+- {test_artifacts}/traceability-matrix.md
+- {test_artifacts}/e2e-trace-summary.json
+- {test_artifacts}/gate-decision.json (when gate-eligible)

--- a/src/workflows/testarch/bmad-testarch-trace/workflow.yaml
+++ b/src/workflows/testarch/bmad-testarch-trace/workflow.yaml
@@ -28,9 +28,31 @@ variables:
   coverage_levels: "e2e,api,component,unit" # Which test levels to trace
   gate_type: "story" # story | epic | release | hotfix - determines gate scope
   decision_mode: "deterministic" # deterministic (rule-based) | manual (team decision)
+  collection_mode: "contract_static" # contract_static | inventory_only | runtime_manifest | deferred_shared | waived | restricted | inaccessible
+  allow_gate: true # Emit gate_status and gate-decision.json only when collection is gate-eligible
+  coverage_basis: "acceptance_criteria" # acceptance_criteria | synthetic_requirements | openapi_endpoints | user_journeys
+  summary_confidence: "high" # high | medium | low
 
 # Output configuration
 default_output_file: "{test_artifacts}/traceability-matrix.md"
+e2e_trace_summary_output: "{test_artifacts}/e2e-trace-summary.json" # Machine-readable summary consumed by CI/CD and reporting pipelines
+gate_decision_output: "{test_artifacts}/gate-decision.json" # Optional downstream gate signal for CI/CD enforcement
+
+# e2e-trace-summary.json schema (emitted by step-05 at workflow completion)
+# schema_version: 1
+# generated_at: ISO timestamp
+# workflow: "bmad-testarch-trace"
+# repo / collection_mode / collection_status / coverage_basis / source_sha
+# target: { type, id, label }
+# gate_status: PASS | CONCERNS | FAIL | WAIVED   (only when allow_gate is true and collection_status is COLLECTED)
+# coverage_statistics: { total_requirements, fully_covered, partially_covered, uncovered, overall_coverage_pct, priority_breakdown{P0..P3}, by_level{e2e,api,component,unit} }
+# tests: { files, cases, skipped_cases, fixme_cases, pending_cases }
+# gap_analysis: { critical_gaps, high_gaps, medium_gaps, low_gaps }
+# heuristics: { endpoint_gaps, auth_negative_path_status, error_path_status }
+# gate_criteria: { p0_coverage_required/actual/status, p1_coverage_target/minimum/actual/status, overall_coverage_minimum/actual/status } (gate-eligible runs only)
+# blockers: [ { id, severity, reason, test_file?, test_title? } ]
+# recommendations: [ { priority, action, requirements[] } ]
+# links: { trace_report_path, trace_report_url, artifact_url }
 
 # Required tools
 required_tools:


### PR DESCRIPTION
 ## Summary                                   
                                                                                                                                          
Add `e2e-trace-summary.json` machine-readable output to the `bmad-testarch-trace` workflow.                                             
                                               
- **New outputs**: `e2e-trace-summary.json` (always emitted) and `gate-decision.json` (gate-eligible runs only), written by Step 5 at  workflow completion. Both are defined as first-class outputs in `workflow.yaml` alongside the existing markdown traceability matrix.

- **Schema design**: Mirrors the `coverage-summary.json` contract pattern from the unit test coverage rollout — any CI/CD pipeline, reporting dashboard, or LLM agent can consume it without parsing markdown. Schema documented inline in `workflow.yaml` as the authoritative contract.                      

- **Data pipeline (Steps 2–4)**: Steps 2 and 3 now capture stable test identity fields (`id`, `title`, `file`, `line`, `level`, status flags) and coverage heuristic signals (endpoint gaps, auth negative-path gaps, happy-path-only criteria) so Step 4 can deduplicate   unique tests across requirements and build accurate counts. Step 4 writes a typed `coverageMatrix` to a temp file and records its resolved path in the progress frontmatter so Step 5 reads the exact same file.                                                          

- **Gate decision assembly (Step 5)**: Reads the Phase 1 matrix, resolves collection status and gate eligibility, applies deterministic  PASS/CONCERNS/FAIL/WAIVED rules, and assembles the full `e2e-trace-summary.json` + slim `gate-decision.json`.                           
   
