### PR TITLE
fix: issue-78   Add explicit status metadata to test-design progress files

### DIFF
--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-01-detect-mode.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-01-detect-mode.md
@@ -106,8 +106,11 @@ State which mode you will use and why. Then proceed.
 
   ```yaml
   ---
+  workflowStatus: 'in-progress'
+  totalSteps: 5
   stepsCompleted: ['step-01-detect-mode']
   lastStep: 'step-01-detect-mode'
+  nextStep: '{nextStepFile}'
   lastSaved: '{date}'
   ---
   ```
@@ -115,8 +118,11 @@ State which mode you will use and why. Then proceed.
   Then write this step's output below the frontmatter.
 
 - **If `{outputFile}` already exists**, update:
+  - Set `workflowStatus: 'in-progress'`
+  - Set `totalSteps: 5`
   - Add `'step-01-detect-mode'` to `stepsCompleted` array (only if not already present)
   - Set `lastStep: 'step-01-detect-mode'`
+  - Set `nextStep: '{nextStepFile}'`
   - Set `lastSaved: '{date}'`
   - Append this step's output to the appropriate section of the document.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-01b-resume.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-01b-resume.md
@@ -37,9 +37,20 @@ Resume an interrupted workflow by loading the existing output document, displayi
 
 Read `{outputFile}` and parse YAML frontmatter for:
 
+- `workflowStatus` — overall workflow state (`in-progress` or `completed`)
+- `totalSteps` — total number of create-mode workflow steps
 - `stepsCompleted` — array of completed step names
 - `lastStep` — last completed step name
+- `nextStep` — next step file to execute
 - `lastSaved` — timestamp of last save
+
+If `workflowStatus`, `totalSteps`, or `nextStep` are missing (legacy progress file), infer them from `lastStep` using this mapping:
+
+- `'step-01-detect-mode'` → `workflowStatus: 'in-progress'`, `totalSteps: 5`, `nextStep: './step-02-load-context.md'`
+- `'step-02-load-context'` → `workflowStatus: 'in-progress'`, `totalSteps: 5`, `nextStep: './step-03-risk-and-testability.md'`
+- `'step-03-risk-and-testability'` → `workflowStatus: 'in-progress'`, `totalSteps: 5`, `nextStep: './step-04-coverage-plan.md'`
+- `'step-04-coverage-plan'` → `workflowStatus: 'in-progress'`, `totalSteps: 5`, `nextStep: './step-05-generate-output.md'`
+- `'step-05-generate-output'` → `workflowStatus: 'completed'`, `totalSteps: 5`, `nextStep: ''`
 
 **If `{outputFile}` does not exist**, display:
 
@@ -55,30 +66,32 @@ Display:
 
 "📋 **Workflow Resume — Test Design and Risk Assessment**
 
+**Workflow status:** {workflowStatus}
 **Last saved:** {lastSaved}
-**Steps completed:** {stepsCompleted.length} of 5
-
-1. ✅/⬜ Detect Mode (step-01-detect-mode)
-2. ✅/⬜ Load Context (step-02-load-context)
-3. ✅/⬜ Risk & Testability (step-03-risk-and-testability)
-4. ✅/⬜ Coverage Plan (step-04-coverage-plan)
-5. ✅/⬜ Generate Output (step-05-generate-output)"
+**Last completed step:** {lastStep}
+**Next step:** {nextStep || 'None'}
+**Steps completed:** {stepsCompleted.length} of {totalSteps}"
 
 ---
 
 ### 3. Route to Next Step
 
-Based on `lastStep`, load the next incomplete step:
+If `workflowStatus` is `'completed'`, display:
+"✅ **All steps completed.** Use **[V] Validate** to review outputs or **[E] Edit** to make revisions."
 
-- `'step-01-detect-mode'` → `./step-02-load-context.md`
-- `'step-02-load-context'` → `./step-03-risk-and-testability.md`
-- `'step-03-risk-and-testability'` → `./step-04-coverage-plan.md`
-- `'step-04-coverage-plan'` → `./step-05-generate-output.md`
-- `'step-05-generate-output'` → **Workflow already complete.** Display: "✅ **All steps completed.** Use **[V] Validate** to review outputs or **[E] Edit** to make revisions." Then halt.
+**THEN:** Halt.
 
-**If `lastStep` does not match any value above**, display: "⚠️ **Unknown progress state** (`lastStep`: {lastStep}). Please use **[C] Create** to start fresh." Then halt.
+If `nextStep` is one of the known create-mode step files below, load it, read completely, and execute:
 
-**Otherwise**, load the identified step file, read completely, and execute.
+- `./step-02-load-context.md`
+- `./step-03-risk-and-testability.md`
+- `./step-04-coverage-plan.md`
+- `./step-05-generate-output.md`
+
+**If `nextStep` is empty or does not match a known step file**, display:
+"⚠️ **Unknown progress state** (`workflowStatus`: {workflowStatus}, `lastStep`: {lastStep}, `nextStep`: {nextStep}). Please use **[C] Create** to start fresh."
+
+**THEN:** Halt.
 
 The existing content in `{outputFile}` provides context from previously completed steps.
 
@@ -89,6 +102,7 @@ The existing content in `{outputFile}` provides context from previously complete
 ### ✅ SUCCESS:
 
 - Output document loaded and parsed correctly
+- Explicit or legacy progress state resolved correctly
 - Progress dashboard displayed accurately
 - Routed to correct next step
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-02-load-context.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-02-load-context.md
@@ -212,8 +212,11 @@ Summarize what was loaded and confirm with the user if anything is missing.
 
   ```yaml
   ---
+  workflowStatus: 'in-progress'
+  totalSteps: 5
   stepsCompleted: ['step-02-load-context']
   lastStep: 'step-02-load-context'
+  nextStep: '{nextStepFile}'
   lastSaved: '{date}'
   ---
   ```
@@ -221,8 +224,11 @@ Summarize what was loaded and confirm with the user if anything is missing.
   Then write this step's output below the frontmatter.
 
 - **If `{outputFile}` already exists**, update:
+  - Set `workflowStatus: 'in-progress'`
+  - Set `totalSteps: 5`
   - Add `'step-02-load-context'` to `stepsCompleted` array (only if not already present)
   - Set `lastStep: 'step-02-load-context'`
+  - Set `nextStep: '{nextStepFile}'`
   - Set `lastSaved: '{date}'`
   - Append this step's output to the appropriate section of the document.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-03-risk-and-testability.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-03-risk-and-testability.md
@@ -82,8 +82,11 @@ Summarize the highest risks and their mitigation priorities.
 
   ```yaml
   ---
+  workflowStatus: 'in-progress'
+  totalSteps: 5
   stepsCompleted: ['step-03-risk-and-testability']
   lastStep: 'step-03-risk-and-testability'
+  nextStep: '{nextStepFile}'
   lastSaved: '{date}'
   ---
   ```
@@ -91,8 +94,11 @@ Summarize the highest risks and their mitigation priorities.
   Then write this step's output below the frontmatter.
 
 - **If `{outputFile}` already exists**, update:
+  - Set `workflowStatus: 'in-progress'`
+  - Set `totalSteps: 5`
   - Add `'step-03-risk-and-testability'` to `stepsCompleted` array (only if not already present)
   - Set `lastStep: 'step-03-risk-and-testability'`
+  - Set `nextStep: '{nextStepFile}'`
   - Set `lastSaved: '{date}'`
   - Append this step's output to the appropriate section of the document.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-04-coverage-plan.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-04-coverage-plan.md
@@ -95,8 +95,11 @@ Define thresholds:
 
   ```yaml
   ---
+  workflowStatus: 'in-progress'
+  totalSteps: 5
   stepsCompleted: ['step-04-coverage-plan']
   lastStep: 'step-04-coverage-plan'
+  nextStep: '{nextStepFile}'
   lastSaved: '{date}'
   ---
   ```
@@ -104,8 +107,11 @@ Define thresholds:
   Then write this step's output below the frontmatter.
 
 - **If `{outputFile}` already exists**, update:
+  - Set `workflowStatus: 'in-progress'`
+  - Set `totalSteps: 5`
   - Add `'step-04-coverage-plan'` to `stepsCompleted` array (only if not already present)
   - Set `lastStep: 'step-04-coverage-plan'`
+  - Set `nextStep: '{nextStepFile}'`
   - Set `lastSaved: '{date}'`
   - Append this step's output to the appropriate section of the document.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-05-generate-output.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-05-generate-output.md
@@ -196,8 +196,11 @@ Summarize:
 
   ```yaml
   ---
+  workflowStatus: 'completed'
+  totalSteps: 5
   stepsCompleted: ['step-05-generate-output']
   lastStep: 'step-05-generate-output'
+  nextStep: ''
   lastSaved: '{date}'
   ---
   ```
@@ -205,8 +208,11 @@ Summarize:
   Then write this step's output below the frontmatter.
 
 - **If `{progressFile}` already exists**, update:
+  - Set `workflowStatus: 'completed'`
+  - Set `totalSteps: 5`
   - Add `'step-05-generate-output'` to `stepsCompleted` array (only if not already present)
   - Set `lastStep: 'step-05-generate-output'`
+  - Set `nextStep: ''`
   - Set `lastSaved: '{date}'`
   - Append this step's output to the appropriate section of the document.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/test-design-architecture-template.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/test-design-architecture-template.md
@@ -1,6 +1,9 @@
 ---
+workflowStatus: ''
+totalSteps: 5
 stepsCompleted: []
 lastStep: ''
+nextStep: ''
 lastSaved: ''
 workflowType: 'testarch-test-design'
 inputDocuments: []

--- a/src/workflows/testarch/bmad-testarch-test-design/test-design-qa-template.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/test-design-qa-template.md
@@ -1,6 +1,9 @@
 ---
+workflowStatus: ''
+totalSteps: 5
 stepsCompleted: []
 lastStep: ''
+nextStep: ''
 lastSaved: ''
 workflowType: 'testarch-test-design'
 inputDocuments: []

--- a/src/workflows/testarch/bmad-testarch-test-design/test-design-template.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/test-design-template.md
@@ -1,6 +1,9 @@
 ---
+workflowStatus: ''
+totalSteps: 5
 stepsCompleted: []
 lastStep: ''
+nextStep: ''
 lastSaved: ''
 ---
 

--- a/src/workflows/testarch/bmad-testarch-test-design/workflow.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/workflow.md
@@ -39,3 +39,5 @@ This workflow uses **tri-modal step-file architecture**:
 - **If R:** Load `steps-c/step-01b-resume.md`
 - **If V:** Load `steps-v/step-01-validate.md`
 - **If E:** Load `steps-e/step-01-assess.md`
+
+Resume mode reads explicit progress metadata from the progress file (`workflowStatus`, `nextStep`, `totalSteps`) and falls back to legacy `lastStep` data when needed.


### PR DESCRIPTION
 ## Summary
 
Adds explicit machine-readable workflow state to the `bmad-testarch-test-design` progress file so agents and tools can resume and validate progress without hard-coding step counts.

Closes https://github.com/bmad-code-org/bmad-method-test-architecture-enterprise/issues/72

## What Changed

- Added `workflowStatus`, `nextStep`, and `totalSteps` to the progress-file frontmatter schema
- Updated create-mode save instructions to write those fields at each step
- Updated final save behavior to mark the workflow as `completed` and clear `nextStep`
- Updated resume logic to read explicit progress metadata instead of relying on `stepsCompleted.length` and a hard-coded `5`
- Kept backward compatibility by inferring the new fields from legacy `lastStep` data when resuming older progress files
- Updated workflow/template docs to reflect the new progress metadata

## Why

Previously, the workflow only tracked completed step names and the last completed step. That made progress interpretation dependent on outside knowledge of the workflow shape. With explicit status metadata in the progress file, resume and validation can use the file itself  as the source of truth.

## Testing

- Reviewed the updated workflow docs and resume flow via diff
- Confirmed the hard-coded `of 5` resume dependency was removed from this workflow
- No automated tests were run because this is a workflow-doc/progress-schema change

