### PR TITLE
feat(agents): move Murat to the software-development team

### DIFF
--- a/src/module.yaml
+++ b/src/module.yaml
@@ -11,7 +11,7 @@ agents:
     title: Master Test Architect and Quality Advisor
     icon: "🧪"
     description: "Risk-based testing strategy, fixture architecture, ATDD, API and UI automation (Playwright, Cypress, pytest, JUnit, Go test, xUnit, RSpec), consumer-driven contract testing (Pact), and performance/load/chaos testing (k6). Speaks in risk calculations and impact assessments; strong opinions, weakly held."
-    team: tea
+    team: software-development
 
 # Variables from Core Config inserted automatically by installer:
 ## user_name

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -181,7 +181,7 @@ async function runTests() {
       assert(teaAgentEntry.name === 'Murat', 'module.yaml bmad-tea entry has name: Murat');
       assert(teaAgentEntry.title && teaAgentEntry.title.length > 0, 'module.yaml bmad-tea entry has a title');
       assert(teaAgentEntry.icon === '🧪', 'module.yaml bmad-tea entry has icon 🧪');
-      assert(teaAgentEntry.team === 'tea', 'module.yaml bmad-tea entry has team: tea');
+      assert(teaAgentEntry.team === 'software-development', 'module.yaml bmad-tea entry has team: software-development');
       assert(
         typeof teaAgentEntry.description === 'string' && teaAgentEntry.description.length > 0,
         'module.yaml bmad-tea entry has a description',


### PR DESCRIPTION
## Summary

Change Murat's `team` in `src/module.yaml` from `tea` to `software-development` so Tea's test architect shares a team with the BMM delivery roster (analyst, tech-writer, PM, UX designer, architect, dev).

## Paired PR

- `BMAD-METHOD` ships the same change across its six agents (`bmad-agent-analyst`, `bmad-agent-tech-writer`, `bmad-agent-pm`, `bmad-agent-ux-designer`, `bmad-agent-architect`, `bmad-agent-dev`) so the full software-delivery roster routes as a single team for party-mode, retrospective, and help catalog skills.

## Test plan

- [ ] Fresh install with BMM + TEA: party-mode and retrospective skills read `team: software-development` from both modules' agent rosters and group Murat with the BMM agents under one team.
- [ ] No regression in Tea's existing workflows (Teach Me Testing, Test Framework, ATDD, etc.) — the team change is metadata only.