### PR TITLE
fix: issue 84 skill path vscode

### DIFF
--- a/docs/how-to/customization/extend-tea-with-custom-workflows.md
+++ b/docs/how-to/customization/extend-tea-with-custom-workflows.md
@@ -60,6 +60,35 @@ Then choose a normal update path so BMAD re-applies the customization and refres
 - Do not rely on old embedded-TEA behavior where local workflows appeared to be attached automatically.
 - Do not keep custom workflow logic only in chat instructions. Put it in a real workflow or module so it survives updates.
 
+## Path-Safe Authoring for GitHub Copilot and Other Workspace-Root Runtimes
+
+Some IDE skill runners, including GitHub Copilot slash commands in VS Code, execute commands from the **workspace root**, not from the folder that contains the installed `SKILL.md`.
+
+Author custom TEA skills and workflows with that constraint in mind:
+
+- Use `{skill-root}` for files that live inside the installed skill package.
+- Use `{project-root}` for files that live in the target repository.
+- Do not assume `scripts/...`, `workflow.md`, `./instructions.md`, or `steps-c/...` will resolve relative to the current markdown file unless you explicitly anchor them.
+
+Use patterns like these:
+
+```md
+Read `{skill-root}/workflow.md` and follow it exactly.
+Load `{skill-root}/steps-c/step-01-preflight.md`.
+Run: `python3 {skill-root}/scripts/resolve_customization.py --key inject`
+Read `{project-root}/_bmad/tea/config.yaml`.
+```
+
+Avoid patterns like these:
+
+```md
+Read `workflow.md`
+Load `steps-c/step-01-preflight.md`
+Run: `python3 scripts/resolve_customization.py --key inject`
+```
+
+This keeps the same skill portable across Codex, Claude Code, GitHub Copilot, and other runtimes that install skills into different directories.
+
 ## When to Use Which Approach
 
 - **Project-specific workflow**: add custom content and attach it to `bmad-tea`

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -228,7 +228,7 @@ See [Extend TEA with Custom Workflows](../how-to/customization/extend-tea-with-c
 
 ```text
 python3 scripts/resolve_customization.py ...
-can't open file 'C:\\path\\to\\workspace\\scripts\\resolve_customization.py': [Errno 2] No such file or directory
+can't open file 'C:\path\to\workspace\scripts\resolve_customization.py': [Errno 2] No such file or directory
 ```
 
 **Cause**: GitHub Copilot executes skill commands from the **workspace root**, not from the installed skill folder under `.github/skills/`.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -222,6 +222,42 @@ See [Extend TEA with Custom Workflows](../how-to/customization/extend-tea-with-c
 
 ## Workflow Execution Issues
 
+### GitHub Copilot Slash Command Fails with "No such file or directory"
+
+**Symptom**: A workflow or custom skill launched through GitHub Copilot in VS Code fails with an error such as:
+
+```text
+python3 scripts/resolve_customization.py ...
+can't open file 'C:\\path\\to\\workspace\\scripts\\resolve_customization.py': [Errno 2] No such file or directory
+```
+
+**Cause**: GitHub Copilot executes skill commands from the **workspace root**, not from the installed skill folder under `.github/skills/`.
+
+**Fix**:
+
+1. Anchor skill-local files with `{skill-root}`.
+2. Anchor repository files with `{project-root}`.
+3. Update workflow entrypoints so sibling files are loaded from `{skill-root}`, not from implicit relative paths.
+
+**Good examples**:
+
+```md
+Read `{skill-root}/workflow.md`
+Load `{skill-root}/steps-c/step-01-preflight.md`
+Run: `python3 {skill-root}/scripts/resolve_customization.py --key inject`
+Read `{project-root}/_bmad/tea/config.yaml`
+```
+
+**Problematic examples**:
+
+```md
+Read `workflow.md`
+Load `steps-c/step-01-preflight.md`
+Run: `python3 scripts/resolve_customization.py --key inject`
+```
+
+If you are creating a custom TEA workflow, see [Extend TEA with Custom Workflows](../how-to/customization/extend-tea-with-custom-workflows.md) and author it with `{skill-root}` / `{project-root}` from the start.
+
 ### Workflow Starts But Produces No Output
 
 **Symptom**: Workflow executes but doesn't generate expected files (test designs, reports, tests).

--- a/src/workflows/testarch/bmad-teach-me-testing/SKILL.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/SKILL.md
@@ -3,4 +3,13 @@ name: bmad-teach-me-testing
 description: 'Teach testing progressively through structured sessions. Use when user says "lets learn testing" or "I want to study test practices"'
 ---
 
-Follow the instructions in [workflow.md](workflow.md).
+## Conventions
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+
+## On Activation
+
+Read `{skill-root}/workflow.md` and follow it exactly.
+
+When `workflow.md`, step files, templates, or checklists reference sibling files with relative paths such as `steps-c/...`, `./instructions.md`, or `templates/...`, resolve them from `{skill-root}`, not from the workspace root.

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-01-init.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-01-init.md
@@ -2,7 +2,7 @@
 name: 'step-01-init'
 description: 'Initialize TEA Academy - check for existing progress and route to continuation or new assessment'
 
-nextStepFile: './step-02-assess.md'
+nextStepFile: '{skill-root}/steps-c/step-02-assess.md'
 continueFile: './step-01b-continue.md'
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
 progressTemplate: '../templates/progress-template.yaml'

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-01b-continue.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-01b-continue.md
@@ -3,7 +3,7 @@ name: 'step-01b-continue'
 description: 'Resume TEA Academy learning - load progress and display dashboard'
 
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
-nextStepFile: './step-03-session-menu.md'
+nextStepFile: '{skill-root}/steps-c/step-03-session-menu.md'
 ---
 
 # Step 1b: Continue TEA Academy

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-02-assess.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-02-assess.md
@@ -2,7 +2,7 @@
 name: 'step-02-assess'
 description: 'Gather learner role, experience level, learning goals, and pain points to customize teaching'
 
-nextStepFile: './step-03-session-menu.md'
+nextStepFile: '{skill-root}/steps-c/step-03-session-menu.md'
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
 ---
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-01.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-01.md
@@ -5,7 +5,7 @@ description: 'Session 1: Quick Start - TEA Lite intro, run automate workflow (30
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
 sessionNotesTemplate: '../templates/session-notes-template.md'
 sessionNotesFile: '{test_artifacts}/tea-academy/{user_name}/session-01-notes.md'
-nextStepFile: './step-03-session-menu.md'
+nextStepFile: '{skill-root}/steps-c/step-03-session-menu.md'
 advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'
 partyModeWorkflow: '{project-root}/_bmad/core/workflows/party-mode/workflow.md'
 ---

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-02.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-02.md
@@ -5,7 +5,7 @@ description: 'Session 2: Core Concepts - Risk-based testing, DoD, testing philos
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
 sessionNotesTemplate: '../templates/session-notes-template.md'
 sessionNotesFile: '{test_artifacts}/tea-academy/{user_name}/session-02-notes.md'
-nextStepFile: './step-03-session-menu.md'
+nextStepFile: '{skill-root}/steps-c/step-03-session-menu.md'
 advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'
 partyModeWorkflow: '{project-root}/_bmad/core/workflows/party-mode/workflow.md'
 ---

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-03.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-03.md
@@ -5,7 +5,7 @@ description: 'Session 3: Architecture & Patterns - Fixtures, network patterns, f
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
 sessionNotesTemplate: '../templates/session-notes-template.md'
 sessionNotesFile: '{test_artifacts}/tea-academy/{user_name}/session-03-notes.md'
-nextStepFile: './step-03-session-menu.md'
+nextStepFile: '{skill-root}/steps-c/step-03-session-menu.md'
 advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'
 partyModeWorkflow: '{project-root}/_bmad/core/workflows/party-mode/workflow.md'
 ---

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-04.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-04.md
@@ -5,7 +5,7 @@ description: 'Session 4: Test Design - Risk assessment, test design workflow (60
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
 sessionNotesTemplate: '../templates/session-notes-template.md'
 sessionNotesFile: '{test_artifacts}/tea-academy/{user_name}/session-04-notes.md'
-nextStepFile: './step-03-session-menu.md'
+nextStepFile: '{skill-root}/steps-c/step-03-session-menu.md'
 advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'
 partyModeWorkflow: '{project-root}/_bmad/core/workflows/party-mode/workflow.md'
 ---

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-05.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-05.md
@@ -5,7 +5,7 @@ description: 'Session 5: ATDD & Automate - TDD red-green approach, generate test
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
 sessionNotesTemplate: '../templates/session-notes-template.md'
 sessionNotesFile: '{test_artifacts}/tea-academy/{user_name}/session-05-notes.md'
-nextStepFile: './step-03-session-menu.md'
+nextStepFile: '{skill-root}/steps-c/step-03-session-menu.md'
 advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'
 partyModeWorkflow: '{project-root}/_bmad/core/workflows/party-mode/workflow.md'
 ---

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-06.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-06.md
@@ -5,7 +5,7 @@ description: 'Session 6: Quality & Trace - Test review, traceability, quality me
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
 sessionNotesTemplate: '../templates/session-notes-template.md'
 sessionNotesFile: '{test_artifacts}/tea-academy/{user_name}/session-06-notes.md'
-nextStepFile: './step-03-session-menu.md'
+nextStepFile: '{skill-root}/steps-c/step-03-session-menu.md'
 advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'
 partyModeWorkflow: '{project-root}/_bmad/core/workflows/party-mode/workflow.md'
 ---

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-07.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-07.md
@@ -5,7 +5,7 @@ description: 'Session 7: Advanced Patterns - Menu-driven knowledge fragment expl
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
 sessionNotesTemplate: '../templates/session-notes-template.md'
 sessionNotesFile: '{test_artifacts}/tea-academy/{user_name}/session-07-notes.md'
-nextStepFile: './step-03-session-menu.md'
+nextStepFile: '{skill-root}/steps-c/step-03-session-menu.md'
 advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'
 partyModeWorkflow: '{project-root}/_bmad/core/workflows/party-mode/workflow.md'
 ---

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-e/step-e-01-assess-workflow.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-e/step-e-01-assess-workflow.md
@@ -2,8 +2,8 @@
 name: 'step-e-01-assess-workflow'
 description: 'Assess what needs to be edited in the teaching workflow'
 
-nextStepFile: './step-e-02-apply-edits.md'
-workflowPath: '../'
+nextStepFile: '{skill-root}/steps-e/step-e-02-apply-edits.md'
+workflowPath: '{skill-root}'
 advancedElicitationTask: '{project-root}/_bmad/core/workflows/advanced-elicitation/workflow.xml'
 partyModeWorkflow: '{project-root}/_bmad/core/workflows/party-mode/workflow.md'
 ---

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-e/step-e-02-apply-edits.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-e/step-e-02-apply-edits.md
@@ -2,7 +2,7 @@
 name: 'step-e-02-apply-edits'
 description: 'Apply modifications to the teaching workflow based on edit plan'
 
-workflowPath: '../'
+workflowPath: '{skill-root}'
 ---
 
 # Edit Step 2: Apply Edits

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
@@ -2,8 +2,8 @@
 name: 'step-v-01-validate'
 description: 'Validate teach-me-testing workflow quality against BMAD standards'
 
-workflowPath: '../'
-checklistFile: '../checklist.md'
+workflowPath: '{skill-root}'
+checklistFile: '{skill-root}/checklist.md'
 validationReport: '{test_artifacts}/workflow-validation/teach-me-testing-validation-{date}.md'
 ---
 

--- a/src/workflows/testarch/bmad-teach-me-testing/workflow.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/workflow.md
@@ -14,6 +14,14 @@ web_bundle: true
 
 ---
 
+## PATH RESOLUTION
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+- Resolve sibling workflow files such as `instructions.md`, `checklist.md`, `steps-c/...`, `steps-e/...`, `steps-v/...`, and templates from `{skill-root}`, not from the workspace root.
+
+---
+
 ## WORKFLOW ARCHITECTURE
 
 This uses **step-file architecture** for disciplined execution:
@@ -79,12 +87,12 @@ Please select: [C]reate / [V]alidate / [E]dit"
 ### 3. Route to First Step
 
 **IF mode == create:**
-Load, read the full file and then execute `./steps-c/step-01-init.md` to begin the teaching workflow.
+Load, read the full file and then execute `{skill-root}/steps-c/step-01-init.md` to begin the teaching workflow.
 
 **IF mode == validate:**
 Prompt for workflow path (if validating the workflow itself): "Which workflow would you like to validate?"
-Then load, read the full file and then execute `./steps-v/step-v-01-validate.md`
+Then load, read the full file and then execute `{skill-root}/steps-v/step-v-01-validate.md`
 
 **IF mode == edit:**
 Prompt for what to edit: "What would you like to edit in the teaching workflow?"
-Then load, read the full file and then execute `./steps-e/step-e-01-assess-workflow.md`
+Then load, read the full file and then execute `{skill-root}/steps-e/step-e-01-assess-workflow.md`

--- a/src/workflows/testarch/bmad-testarch-atdd/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/SKILL.md
@@ -3,4 +3,13 @@ name: bmad-testarch-atdd
 description: 'Generate red-phase acceptance test scaffolds using the TDD cycle. Use when the user says "lets write acceptance tests" or "I want to do ATDD"'
 ---
 
-Follow the instructions in [workflow.md](workflow.md).
+## Conventions
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+
+## On Activation
+
+Read `{skill-root}/workflow.md` and follow it exactly.
+
+When `workflow.md`, step files, templates, or checklists reference sibling files with relative paths such as `steps-c/...`, `./instructions.md`, or `templates/...`, resolve them from `{skill-root}`, not from the workspace root.

--- a/src/workflows/testarch/bmad-testarch-atdd/instructions.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/instructions.md
@@ -34,11 +34,11 @@ From `workflow.yaml`, resolve:
 ### 2. First Step
 
 Load, read completely, and execute:
-`./steps-c/step-01-preflight-and-context.md`
+`{skill-root}/steps-c/step-01-preflight-and-context.md`
 
 ### 3. Resume Support
 
 If the user selects **Resume** mode, load, read completely, and execute:
-`./steps-c/step-01b-resume.md`
+`{skill-root}/steps-c/step-01b-resume.md`
 
 This checks the output document for progress tracking frontmatter and routes to the next incomplete step.

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-01-preflight-and-context.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-01-preflight-and-context.md
@@ -2,7 +2,7 @@
 name: 'step-01-preflight-and-context'
 description: 'Verify prerequisites and load story, framework, and knowledge base'
 outputFile: '{test_artifacts}/atdd-checklist-{story_key}.md'
-nextStepFile: './step-02-generation-mode.md'
+nextStepFile: '{skill-root}/steps-c/step-02-generation-mode.md'
 knowledgeIndex: './resources/tea-index.csv'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-02-generation-mode.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-02-generation-mode.md
@@ -2,7 +2,7 @@
 name: 'step-02-generation-mode'
 description: 'Choose AI generation or recording mode'
 outputFile: '{test_artifacts}/atdd-checklist-{story_key}.md'
-nextStepFile: './step-03-test-strategy.md'
+nextStepFile: '{skill-root}/steps-c/step-03-test-strategy.md'
 ---
 
 # Step 2: Generation Mode Selection

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-03-test-strategy.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-03-test-strategy.md
@@ -2,7 +2,7 @@
 name: 'step-03-test-strategy'
 description: 'Map acceptance criteria to test levels and priorities'
 outputFile: '{test_artifacts}/atdd-checklist-{story_key}.md'
-nextStepFile: './step-04-generate-tests.md'
+nextStepFile: '{skill-root}/steps-c/step-04-generate-tests.md'
 ---
 
 # Step 3: Test Strategy

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-04-generate-tests.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-04-generate-tests.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-04-generate-tests'
 description: 'Orchestrate adaptive red-phase test scaffold generation (TDD red phase)'
-nextStepFile: './step-04c-aggregate.md'
+nextStepFile: '{skill-root}/steps-c/step-04c-aggregate.md'
 ---
 
 # Step 4: Orchestrate Adaptive Red-Phase Test Scaffold Generation

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-04c-aggregate.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-04c-aggregate.md
@@ -2,7 +2,7 @@
 name: 'step-04c-aggregate'
 description: 'Aggregate subagent outputs and complete ATDD test infrastructure'
 outputFile: '{test_artifacts}/atdd-checklist-{story_key}.md'
-nextStepFile: './step-05-validate-and-complete.md'
+nextStepFile: '{skill-root}/steps-c/step-05-validate-and-complete.md'
 ---
 
 # Step 4C: Aggregate ATDD Test Generation Results

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-e/step-01-assess.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-e/step-01-assess.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-assess'
 description: 'Load an existing output for editing'
-nextStepFile: './step-02-apply-edit.md'
+nextStepFile: '{skill-root}/steps-e/step-02-apply-edit.md'
 ---
 
 # Step 1: Assess Edit Target

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-v/step-01-validate.md
@@ -2,7 +2,7 @@
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
 outputFile: '{test_artifacts}/atdd-validation-report.md'
-validationChecklist: '../checklist.md'
+validationChecklist: '{skill-root}/checklist.md'
 ---
 
 # Step 1: Validate Outputs

--- a/src/workflows/testarch/bmad-testarch-atdd/workflow.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/workflow.md
@@ -12,6 +12,14 @@ web_bundle: true
 
 ---
 
+## PATH RESOLUTION
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+- Resolve sibling workflow files such as `instructions.md`, `checklist.md`, `steps-c/...`, `steps-e/...`, `steps-v/...`, and templates from `{skill-root}`, not from the workspace root.
+
+---
+
 ## WORKFLOW ARCHITECTURE
 
 This workflow uses **tri-modal step-file architecture**:
@@ -35,7 +43,7 @@ This workflow uses **tri-modal step-file architecture**:
 
 ### 2. Route to First Step
 
-- **If C:** Load `steps-c/step-01-preflight-and-context.md`
-- **If R:** Load `steps-c/step-01b-resume.md`
-- **If V:** Load `steps-v/step-01-validate.md`
-- **If E:** Load `steps-e/step-01-assess.md`
+- **If C:** Load `{skill-root}/steps-c/step-01-preflight-and-context.md`
+- **If R:** Load `{skill-root}/steps-c/step-01b-resume.md`
+- **If V:** Load `{skill-root}/steps-v/step-01-validate.md`
+- **If E:** Load `{skill-root}/steps-e/step-01-assess.md`

--- a/src/workflows/testarch/bmad-testarch-automate/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-automate/SKILL.md
@@ -3,4 +3,13 @@ name: bmad-testarch-automate
 description: 'Expand test automation coverage for codebase. Use when user says "lets expand test coverage" or "I want to automate tests"'
 ---
 
-Follow the instructions in [workflow.md](workflow.md).
+## Conventions
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+
+## On Activation
+
+Read `{skill-root}/workflow.md` and follow it exactly.
+
+When `workflow.md`, step files, templates, or checklists reference sibling files with relative paths such as `steps-c/...`, `./instructions.md`, or `templates/...`, resolve them from `{skill-root}`, not from the workspace root.

--- a/src/workflows/testarch/bmad-testarch-automate/instructions.md
+++ b/src/workflows/testarch/bmad-testarch-automate/instructions.md
@@ -39,11 +39,11 @@ From `workflow.yaml`, resolve:
 ### 2. First Step
 
 Load, read completely, and execute:
-`./steps-c/step-01-preflight-and-context.md`
+`{skill-root}/steps-c/step-01-preflight-and-context.md`
 
 ### 3. Resume Support
 
 If the user selects **Resume** mode, load, read completely, and execute:
-`./steps-c/step-01b-resume.md`
+`{skill-root}/steps-c/step-01b-resume.md`
 
 This checks the output document for progress tracking frontmatter and routes to the next incomplete step.

--- a/src/workflows/testarch/bmad-testarch-automate/steps-c/step-01-preflight-and-context.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-c/step-01-preflight-and-context.md
@@ -2,7 +2,7 @@
 name: 'step-01-preflight-and-context'
 description: 'Determine mode, verify framework, and load context and knowledge'
 outputFile: '{test_artifacts}/automation-summary.md'
-nextStepFile: './step-02-identify-targets.md'
+nextStepFile: '{skill-root}/steps-c/step-02-identify-targets.md'
 knowledgeIndex: './resources/tea-index.csv'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-automate/steps-c/step-02-identify-targets.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-c/step-02-identify-targets.md
@@ -2,7 +2,7 @@
 name: 'step-02-identify-targets'
 description: 'Identify automation targets and create coverage plan'
 outputFile: '{test_artifacts}/automation-summary.md'
-nextStepFile: './step-03-generate-tests.md'
+nextStepFile: '{skill-root}/steps-c/step-03-generate-tests.md'
 ---
 
 # Step 2: Identify Automation Targets

--- a/src/workflows/testarch/bmad-testarch-automate/steps-c/step-03-generate-tests.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-c/step-03-generate-tests.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-03-generate-tests'
 description: 'Orchestrate adaptive test generation (agent-team, subagent, or sequential)'
-nextStepFile: './step-03c-aggregate.md'
+nextStepFile: '{skill-root}/steps-c/step-03c-aggregate.md'
 ---
 
 # Step 3: Orchestrate Adaptive Test Generation

--- a/src/workflows/testarch/bmad-testarch-automate/steps-c/step-03c-aggregate.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-c/step-03c-aggregate.md
@@ -2,7 +2,7 @@
 name: 'step-03c-aggregate'
 description: 'Aggregate subagent outputs and complete test infrastructure'
 outputFile: '{test_artifacts}/automation-summary.md'
-nextStepFile: './step-04-validate-and-summarize.md'
+nextStepFile: '{skill-root}/steps-c/step-04-validate-and-summarize.md'
 ---
 
 # Step 3C: Aggregate Test Generation Results

--- a/src/workflows/testarch/bmad-testarch-automate/steps-e/step-01-assess.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-e/step-01-assess.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-assess'
 description: 'Load an existing output for editing'
-nextStepFile: './step-02-apply-edit.md'
+nextStepFile: '{skill-root}/steps-e/step-02-apply-edit.md'
 ---
 
 # Step 1: Assess Edit Target

--- a/src/workflows/testarch/bmad-testarch-automate/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-v/step-01-validate.md
@@ -2,7 +2,7 @@
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
 outputFile: '{test_artifacts}/automate-validation-report.md'
-validationChecklist: '../checklist.md'
+validationChecklist: '{skill-root}/checklist.md'
 ---
 
 # Step 1: Validate Outputs

--- a/src/workflows/testarch/bmad-testarch-automate/workflow.md
+++ b/src/workflows/testarch/bmad-testarch-automate/workflow.md
@@ -12,6 +12,14 @@ web_bundle: true
 
 ---
 
+## PATH RESOLUTION
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+- Resolve sibling workflow files such as `instructions.md`, `checklist.md`, `steps-c/...`, `steps-e/...`, `steps-v/...`, and templates from `{skill-root}`, not from the workspace root.
+
+---
+
 ## WORKFLOW ARCHITECTURE
 
 This workflow uses **tri-modal step-file architecture**:
@@ -35,7 +43,7 @@ This workflow uses **tri-modal step-file architecture**:
 
 ### 2. Route to First Step
 
-- **If C:** Load `steps-c/step-01-preflight-and-context.md`
-- **If R:** Load `steps-c/step-01b-resume.md`
-- **If V:** Load `steps-v/step-01-validate.md`
-- **If E:** Load `steps-e/step-01-assess.md`
+- **If C:** Load `{skill-root}/steps-c/step-01-preflight-and-context.md`
+- **If R:** Load `{skill-root}/steps-c/step-01b-resume.md`
+- **If V:** Load `{skill-root}/steps-v/step-01-validate.md`
+- **If E:** Load `{skill-root}/steps-e/step-01-assess.md`

--- a/src/workflows/testarch/bmad-testarch-ci/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-ci/SKILL.md
@@ -3,4 +3,13 @@ name: bmad-testarch-ci
 description: 'Scaffold CI/CD quality pipeline with test execution. Use when the user says "lets setup CI pipeline" or "I want to create quality gates"'
 ---
 
-Follow the instructions in [workflow.md](workflow.md).
+## Conventions
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+
+## On Activation
+
+Read `{skill-root}/workflow.md` and follow it exactly.
+
+When `workflow.md`, step files, templates, or checklists reference sibling files with relative paths such as `steps-c/...`, `./instructions.md`, or `templates/...`, resolve them from `{skill-root}`, not from the workspace root.

--- a/src/workflows/testarch/bmad-testarch-ci/instructions.md
+++ b/src/workflows/testarch/bmad-testarch-ci/instructions.md
@@ -34,11 +34,11 @@ From `workflow.yaml`, resolve:
 ### 2. First Step
 
 Load, read completely, and execute:
-`./steps-c/step-01-preflight.md`
+`{skill-root}/steps-c/step-01-preflight.md`
 
 ### 3. Resume Support
 
 If the user selects **Resume** mode, load, read completely, and execute:
-`./steps-c/step-01b-resume.md`
+`{skill-root}/steps-c/step-01b-resume.md`
 
 This checks the output document for progress tracking frontmatter and routes to the next incomplete step.

--- a/src/workflows/testarch/bmad-testarch-ci/steps-c/step-01-preflight.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-c/step-01-preflight.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-preflight'
 description: 'Verify prerequisites and detect CI platform'
-nextStepFile: './step-02-generate-pipeline.md'
+nextStepFile: '{skill-root}/steps-c/step-02-generate-pipeline.md'
 outputFile: '{test_artifacts}/ci-pipeline-progress.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-ci/steps-c/step-02-generate-pipeline.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-c/step-02-generate-pipeline.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-02-generate-pipeline'
 description: 'Generate CI pipeline configuration with adaptive orchestration (agent-team, subagent, or sequential)'
-nextStepFile: './step-03-configure-quality-gates.md'
+nextStepFile: '{skill-root}/steps-c/step-03-configure-quality-gates.md'
 knowledgeIndex: './resources/tea-index.csv'
 outputFile: '{test_artifacts}/ci-pipeline-progress.md'
 ---

--- a/src/workflows/testarch/bmad-testarch-ci/steps-c/step-03-configure-quality-gates.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-c/step-03-configure-quality-gates.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-03-configure-quality-gates'
 description: 'Configure burn-in, quality gates, and notifications'
-nextStepFile: './step-04-validate-and-summary.md'
+nextStepFile: '{skill-root}/steps-c/step-04-validate-and-summary.md'
 knowledgeIndex: './resources/tea-index.csv'
 outputFile: '{test_artifacts}/ci-pipeline-progress.md'
 ---

--- a/src/workflows/testarch/bmad-testarch-ci/steps-e/step-01-assess.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-e/step-01-assess.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-assess'
 description: 'Load an existing output for editing'
-nextStepFile: './step-02-apply-edit.md'
+nextStepFile: '{skill-root}/steps-e/step-02-apply-edit.md'
 ---
 
 # Step 1: Assess Edit Target

--- a/src/workflows/testarch/bmad-testarch-ci/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-v/step-01-validate.md
@@ -2,7 +2,7 @@
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
 outputFile: '{test_artifacts}/ci-validation-report.md'
-validationChecklist: '../checklist.md'
+validationChecklist: '{skill-root}/checklist.md'
 ---
 
 # Step 1: Validate Outputs

--- a/src/workflows/testarch/bmad-testarch-ci/workflow.md
+++ b/src/workflows/testarch/bmad-testarch-ci/workflow.md
@@ -12,6 +12,14 @@ web_bundle: true
 
 ---
 
+## PATH RESOLUTION
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+- Resolve sibling workflow files such as `instructions.md`, `checklist.md`, `steps-c/...`, `steps-e/...`, `steps-v/...`, and templates from `{skill-root}`, not from the workspace root.
+
+---
+
 ## WORKFLOW ARCHITECTURE
 
 This workflow uses **tri-modal step-file architecture**:
@@ -35,7 +43,7 @@ This workflow uses **tri-modal step-file architecture**:
 
 ### 2. Route to First Step
 
-- **If C:** Load `steps-c/step-01-preflight.md`
-- **If R:** Load `steps-c/step-01b-resume.md`
-- **If V:** Load `steps-v/step-01-validate.md`
-- **If E:** Load `steps-e/step-01-assess.md`
+- **If C:** Load `{skill-root}/steps-c/step-01-preflight.md`
+- **If R:** Load `{skill-root}/steps-c/step-01b-resume.md`
+- **If V:** Load `{skill-root}/steps-v/step-01-validate.md`
+- **If E:** Load `{skill-root}/steps-e/step-01-assess.md`

--- a/src/workflows/testarch/bmad-testarch-framework/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-framework/SKILL.md
@@ -3,4 +3,13 @@ name: bmad-testarch-framework
 description: 'Initialize test framework with Playwright or Cypress. Use when the user says "lets setup test framework" or "I want to initialize testing framework"'
 ---
 
-Follow the instructions in [workflow.md](workflow.md).
+## Conventions
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+
+## On Activation
+
+Read `{skill-root}/workflow.md` and follow it exactly.
+
+When `workflow.md`, step files, templates, or checklists reference sibling files with relative paths such as `steps-c/...`, `./instructions.md`, or `templates/...`, resolve them from `{skill-root}`, not from the workspace root.

--- a/src/workflows/testarch/bmad-testarch-framework/instructions.md
+++ b/src/workflows/testarch/bmad-testarch-framework/instructions.md
@@ -34,11 +34,11 @@ From `workflow.yaml`, resolve:
 ### 2. First Step
 
 Load, read completely, and execute:
-`./steps-c/step-01-preflight.md`
+`{skill-root}/steps-c/step-01-preflight.md`
 
 ### 3. Resume Support
 
 If the user selects **Resume** mode, load, read completely, and execute:
-`./steps-c/step-01b-resume.md`
+`{skill-root}/steps-c/step-01b-resume.md`
 
 This checks the output document for progress tracking frontmatter and routes to the next incomplete step.

--- a/src/workflows/testarch/bmad-testarch-framework/steps-c/step-01-preflight.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-c/step-01-preflight.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-preflight'
 description: 'Verify prerequisites and gather project context'
-nextStepFile: './step-02-select-framework.md'
+nextStepFile: '{skill-root}/steps-c/step-02-select-framework.md'
 outputFile: '{test_artifacts}/framework-setup-progress.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-framework/steps-c/step-02-select-framework.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-c/step-02-select-framework.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-02-select-framework'
 description: 'Select Playwright or Cypress and justify choice'
-nextStepFile: './step-03-scaffold-framework.md'
+nextStepFile: '{skill-root}/steps-c/step-03-scaffold-framework.md'
 outputFile: '{test_artifacts}/framework-setup-progress.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-framework/steps-c/step-03-scaffold-framework.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-c/step-03-scaffold-framework.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-03-scaffold-framework'
 description: 'Create framework scaffold with adaptive orchestration (agent-team, subagent, or sequential)'
-nextStepFile: './step-04-docs-and-scripts.md'
+nextStepFile: '{skill-root}/steps-c/step-04-docs-and-scripts.md'
 knowledgeIndex: './resources/tea-index.csv'
 outputFile: '{test_artifacts}/framework-setup-progress.md'
 ---

--- a/src/workflows/testarch/bmad-testarch-framework/steps-c/step-04-docs-and-scripts.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-c/step-04-docs-and-scripts.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-04-docs-and-scripts'
 description: 'Document setup and add package.json scripts'
-nextStepFile: './step-05-validate-and-summary.md'
+nextStepFile: '{skill-root}/steps-c/step-05-validate-and-summary.md'
 outputFile: '{test_dir}/README.md'
 progressFile: '{test_artifacts}/framework-setup-progress.md'
 ---

--- a/src/workflows/testarch/bmad-testarch-framework/steps-e/step-01-assess.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-e/step-01-assess.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-assess'
 description: 'Load an existing output for editing'
-nextStepFile: './step-02-apply-edit.md'
+nextStepFile: '{skill-root}/steps-e/step-02-apply-edit.md'
 ---
 
 # Step 1: Assess Edit Target

--- a/src/workflows/testarch/bmad-testarch-framework/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-v/step-01-validate.md
@@ -2,7 +2,7 @@
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
 outputFile: '{test_artifacts}/framework-validation-report.md'
-validationChecklist: '../checklist.md'
+validationChecklist: '{skill-root}/checklist.md'
 ---
 
 # Step 1: Validate Outputs

--- a/src/workflows/testarch/bmad-testarch-framework/workflow.md
+++ b/src/workflows/testarch/bmad-testarch-framework/workflow.md
@@ -12,6 +12,14 @@ web_bundle: true
 
 ---
 
+## PATH RESOLUTION
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+- Resolve sibling workflow files such as `instructions.md`, `checklist.md`, `steps-c/...`, `steps-e/...`, `steps-v/...`, and templates from `{skill-root}`, not from the workspace root.
+
+---
+
 ## WORKFLOW ARCHITECTURE
 
 This workflow uses **tri-modal step-file architecture**:
@@ -35,7 +43,7 @@ This workflow uses **tri-modal step-file architecture**:
 
 ### 2. Route to First Step
 
-- **If C:** Load `steps-c/step-01-preflight.md`
-- **If R:** Load `steps-c/step-01b-resume.md`
-- **If V:** Load `steps-v/step-01-validate.md`
-- **If E:** Load `steps-e/step-01-assess.md`
+- **If C:** Load `{skill-root}/steps-c/step-01-preflight.md`
+- **If R:** Load `{skill-root}/steps-c/step-01b-resume.md`
+- **If V:** Load `{skill-root}/steps-v/step-01-validate.md`
+- **If E:** Load `{skill-root}/steps-e/step-01-assess.md`

--- a/src/workflows/testarch/bmad-testarch-nfr/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/SKILL.md
@@ -3,4 +3,13 @@ name: bmad-testarch-nfr
 description: 'Assess NFRs like performance security and reliability. Use when the user says "lets assess NFRs" or "I want to evaluate non-functional requirements"'
 ---
 
-Follow the instructions in [workflow.md](workflow.md).
+## Conventions
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+
+## On Activation
+
+Read `{skill-root}/workflow.md` and follow it exactly.
+
+When `workflow.md`, step files, templates, or checklists reference sibling files with relative paths such as `steps-c/...`, `./instructions.md`, or `templates/...`, resolve them from `{skill-root}`, not from the workspace root.

--- a/src/workflows/testarch/bmad-testarch-nfr/instructions.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/instructions.md
@@ -33,11 +33,11 @@ From `workflow.yaml`, resolve:
 ### 2. First Step
 
 Load, read completely, and execute:
-`./steps-c/step-01-load-context.md`
+`{skill-root}/steps-c/step-01-load-context.md`
 
 ### 3. Resume Support
 
 If the user selects **Resume** mode, load, read completely, and execute:
-`./steps-c/step-01b-resume.md`
+`{skill-root}/steps-c/step-01b-resume.md`
 
 This checks the output document for progress tracking frontmatter and routes to the next incomplete step.

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-01-load-context.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-01-load-context.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-load-context'
 description: 'Load NFR requirements, evidence sources, and knowledge base'
-nextStepFile: './step-02-define-thresholds.md'
+nextStepFile: '{skill-root}/steps-c/step-02-define-thresholds.md'
 knowledgeIndex: './resources/tea-index.csv'
 outputFile: '{test_artifacts}/nfr-assessment.md'
 ---

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-02-define-thresholds.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-02-define-thresholds.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-02-define-thresholds'
 description: 'Identify NFR categories and thresholds'
-nextStepFile: './step-03-gather-evidence.md'
+nextStepFile: '{skill-root}/steps-c/step-03-gather-evidence.md'
 outputFile: '{test_artifacts}/nfr-assessment.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-03-gather-evidence.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-03-gather-evidence.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-03-gather-evidence'
 description: 'Collect evidence for each NFR category'
-nextStepFile: './step-04-evaluate-and-score.md'
+nextStepFile: '{skill-root}/steps-c/step-04-evaluate-and-score.md'
 outputFile: '{test_artifacts}/nfr-assessment.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-04-evaluate-and-score.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-04-evaluate-and-score.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-04-evaluate-and-score'
 description: 'Orchestrate adaptive NFR domain assessments (agent-team, subagent, or sequential)'
-nextStepFile: './step-04e-aggregate-nfr.md'
+nextStepFile: '{skill-root}/steps-c/step-04e-aggregate-nfr.md'
 ---
 
 # Step 4: Orchestrate Adaptive NFR Assessment

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-04e-aggregate-nfr.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-04e-aggregate-nfr.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-04e-aggregate-nfr'
 description: 'Aggregate NFR domain assessments into executive summary'
-nextStepFile: './step-05-generate-report.md'
+nextStepFile: '{skill-root}/steps-c/step-05-generate-report.md'
 outputFile: '{test_artifacts}/nfr-assessment.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-e/step-01-assess.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-e/step-01-assess.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-assess'
 description: 'Load an existing output for editing'
-nextStepFile: './step-02-apply-edit.md'
+nextStepFile: '{skill-root}/steps-e/step-02-apply-edit.md'
 ---
 
 # Step 1: Assess Edit Target

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-v/step-01-validate.md
@@ -2,7 +2,7 @@
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
 outputFile: '{test_artifacts}/nfr-assess-validation-report.md'
-validationChecklist: '../checklist.md'
+validationChecklist: '{skill-root}/checklist.md'
 ---
 
 # Step 1: Validate Outputs

--- a/src/workflows/testarch/bmad-testarch-nfr/workflow.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/workflow.md
@@ -12,6 +12,14 @@ web_bundle: true
 
 ---
 
+## PATH RESOLUTION
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+- Resolve sibling workflow files such as `instructions.md`, `checklist.md`, `steps-c/...`, `steps-e/...`, `steps-v/...`, and templates from `{skill-root}`, not from the workspace root.
+
+---
+
 ## WORKFLOW ARCHITECTURE
 
 This workflow uses **tri-modal step-file architecture**:
@@ -35,7 +43,7 @@ This workflow uses **tri-modal step-file architecture**:
 
 ### 2. Route to First Step
 
-- **If C:** Load `steps-c/step-01-load-context.md`
-- **If R:** Load `steps-c/step-01b-resume.md`
-- **If V:** Load `steps-v/step-01-validate.md`
-- **If E:** Load `steps-e/step-01-assess.md`
+- **If C:** Load `{skill-root}/steps-c/step-01-load-context.md`
+- **If R:** Load `{skill-root}/steps-c/step-01b-resume.md`
+- **If V:** Load `{skill-root}/steps-v/step-01-validate.md`
+- **If E:** Load `{skill-root}/steps-e/step-01-assess.md`

--- a/src/workflows/testarch/bmad-testarch-test-design/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/SKILL.md
@@ -3,4 +3,13 @@ name: bmad-testarch-test-design
 description: 'Create system-level or epic-level test plans. Use when the user says "lets design test plan" or "I want to create test strategy"'
 ---
 
-Follow the instructions in [workflow.md](workflow.md).
+## Conventions
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+
+## On Activation
+
+Read `{skill-root}/workflow.md` and follow it exactly.
+
+When `workflow.md`, step files, templates, or checklists reference sibling files with relative paths such as `steps-c/...`, `./instructions.md`, or `templates/...`, resolve them from `{skill-root}`, not from the workspace root.

--- a/src/workflows/testarch/bmad-testarch-test-design/instructions.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/instructions.md
@@ -48,12 +48,12 @@ From `workflow.yaml`, resolve:
 ### 2. First Step
 
 Load, read completely, and execute:
-`./steps-c/step-01-detect-mode.md`
+`{skill-root}/steps-c/step-01-detect-mode.md`
 
 ### 3. Resume Support
 
 If the user selects **Resume** mode, load, read completely, and execute:
-`./steps-c/step-01b-resume.md`
+`{skill-root}/steps-c/step-01b-resume.md`
 
 This checks the output document for progress tracking frontmatter and routes to the next incomplete step.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-01-detect-mode.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-01-detect-mode.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-detect-mode'
 description: 'Determine system-level vs epic-level mode and validate prerequisites'
-nextStepFile: './step-02-load-context.md'
+nextStepFile: '{skill-root}/steps-c/step-02-load-context.md'
 outputFile: '{test_artifacts}/test-design-progress.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-02-load-context.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-02-load-context.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-02-load-context'
 description: 'Load documents, configuration, and knowledge fragments for the chosen mode'
-nextStepFile: './step-03-risk-and-testability.md'
+nextStepFile: '{skill-root}/steps-c/step-03-risk-and-testability.md'
 knowledgeIndex: './resources/tea-index.csv'
 outputFile: '{test_artifacts}/test-design-progress.md'
 ---

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-03-risk-and-testability.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-03-risk-and-testability.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-03-risk-and-testability'
 description: 'Perform testability review (system-level) and risk assessment'
-nextStepFile: './step-04-coverage-plan.md'
+nextStepFile: '{skill-root}/steps-c/step-04-coverage-plan.md'
 outputFile: '{test_artifacts}/test-design-progress.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-04-coverage-plan.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-04-coverage-plan.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-04-coverage-plan'
 description: 'Design test coverage, priorities, execution strategy, and estimates'
-nextStepFile: './step-05-generate-output.md'
+nextStepFile: '{skill-root}/steps-c/step-05-generate-output.md'
 outputFile: '{test_artifacts}/test-design-progress.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-e/step-01-assess.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-e/step-01-assess.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-assess'
 description: 'Load an existing output for editing'
-nextStepFile: './step-02-apply-edit.md'
+nextStepFile: '{skill-root}/steps-e/step-02-apply-edit.md'
 ---
 
 # Step 1: Assess Edit Target

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-v/step-01-validate.md
@@ -2,7 +2,7 @@
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
 outputFile: '{test_artifacts}/test-design-validation-report.md'
-validationChecklist: '../checklist.md'
+validationChecklist: '{skill-root}/checklist.md'
 ---
 
 # Step 1: Validate Outputs

--- a/src/workflows/testarch/bmad-testarch-test-design/workflow.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/workflow.md
@@ -12,6 +12,14 @@ web_bundle: true
 
 ---
 
+## PATH RESOLUTION
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+- Resolve sibling workflow files such as `instructions.md`, `checklist.md`, `steps-c/...`, `steps-e/...`, `steps-v/...`, and templates from `{skill-root}`, not from the workspace root.
+
+---
+
 ## WORKFLOW ARCHITECTURE
 
 This workflow uses **tri-modal step-file architecture**:
@@ -35,9 +43,9 @@ This workflow uses **tri-modal step-file architecture**:
 
 ### 2. Route to First Step
 
-- **If C:** Load `steps-c/step-01-detect-mode.md`
-- **If R:** Load `steps-c/step-01b-resume.md`
-- **If V:** Load `steps-v/step-01-validate.md`
-- **If E:** Load `steps-e/step-01-assess.md`
+- **If C:** Load `{skill-root}/steps-c/step-01-detect-mode.md`
+- **If R:** Load `{skill-root}/steps-c/step-01b-resume.md`
+- **If V:** Load `{skill-root}/steps-v/step-01-validate.md`
+- **If E:** Load `{skill-root}/steps-e/step-01-assess.md`
 
 Resume mode reads explicit progress metadata from the progress file (`workflowStatus`, `nextStep`, `totalSteps`) and falls back to legacy `lastStep` data when needed.

--- a/src/workflows/testarch/bmad-testarch-test-review/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/SKILL.md
@@ -3,4 +3,13 @@ name: bmad-testarch-test-review
 description: 'Review test quality using best practices validation. Use when user says "lets review tests" or "I want to evaluate test quality"'
 ---
 
-Follow the instructions in [workflow.md](workflow.md).
+## Conventions
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+
+## On Activation
+
+Read `{skill-root}/workflow.md` and follow it exactly.
+
+When `workflow.md`, step files, templates, or checklists reference sibling files with relative paths such as `steps-c/...`, `./instructions.md`, or `templates/...`, resolve them from `{skill-root}`, not from the workspace root.

--- a/src/workflows/testarch/bmad-testarch-test-review/instructions.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/instructions.md
@@ -35,11 +35,11 @@ From `workflow.yaml`, resolve:
 ### 2. First Step
 
 Load, read completely, and execute:
-`./steps-c/step-01-load-context.md`
+`{skill-root}/steps-c/step-01-load-context.md`
 
 ### 3. Resume Support
 
 If the user selects **Resume** mode, load, read completely, and execute:
-`./steps-c/step-01b-resume.md`
+`{skill-root}/steps-c/step-01b-resume.md`
 
 This checks the output document for progress tracking frontmatter and routes to the next incomplete step.

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-01-load-context.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-01-load-context.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-load-context'
 description: 'Load knowledge base, determine scope, and gather context'
-nextStepFile: './step-02-discover-tests.md'
+nextStepFile: '{skill-root}/steps-c/step-02-discover-tests.md'
 knowledgeIndex: './resources/tea-index.csv'
 outputFile: '{test_artifacts}/test-review.md'
 ---

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-02-discover-tests.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-02-discover-tests.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-02-discover-tests'
 description: 'Find and parse test files'
-nextStepFile: './step-03-quality-evaluation.md'
+nextStepFile: '{skill-root}/steps-c/step-03-quality-evaluation.md'
 outputFile: '{test_artifacts}/test-review.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-03-quality-evaluation.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-03-quality-evaluation.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-03-quality-evaluation'
 description: 'Orchestrate adaptive quality dimension checks (agent-team, subagent, or sequential)'
-nextStepFile: './step-03f-aggregate-scores.md'
+nextStepFile: '{skill-root}/steps-c/step-03f-aggregate-scores.md'
 ---
 
 # Step 3: Orchestrate Adaptive Quality Evaluation

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-03f-aggregate-scores.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-03f-aggregate-scores.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-03f-aggregate-scores'
 description: 'Aggregate quality dimension scores into overall 0-100 score'
-nextStepFile: './step-04-generate-report.md'
+nextStepFile: '{skill-root}/steps-c/step-04-generate-report.md'
 outputFile: '{test_artifacts}/test-review.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-e/step-01-assess.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-e/step-01-assess.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-assess'
 description: 'Load an existing output for editing'
-nextStepFile: './step-02-apply-edit.md'
+nextStepFile: '{skill-root}/steps-e/step-02-apply-edit.md'
 ---
 
 # Step 1: Assess Edit Target

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-v/step-01-validate.md
@@ -2,7 +2,7 @@
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
 outputFile: '{test_artifacts}/test-review-validation-report.md'
-validationChecklist: '../checklist.md'
+validationChecklist: '{skill-root}/checklist.md'
 ---
 
 # Step 1: Validate Outputs

--- a/src/workflows/testarch/bmad-testarch-test-review/workflow.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/workflow.md
@@ -12,6 +12,14 @@ web_bundle: true
 
 ---
 
+## PATH RESOLUTION
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+- Resolve sibling workflow files such as `instructions.md`, `checklist.md`, `steps-c/...`, `steps-e/...`, `steps-v/...`, and templates from `{skill-root}`, not from the workspace root.
+
+---
+
 ## WORKFLOW ARCHITECTURE
 
 This workflow uses **tri-modal step-file architecture**:
@@ -35,7 +43,7 @@ This workflow uses **tri-modal step-file architecture**:
 
 ### 2. Route to First Step
 
-- **If C:** Load `steps-c/step-01-load-context.md`
-- **If R:** Load `steps-c/step-01b-resume.md`
-- **If V:** Load `steps-v/step-01-validate.md`
-- **If E:** Load `steps-e/step-01-assess.md`
+- **If C:** Load `{skill-root}/steps-c/step-01-load-context.md`
+- **If R:** Load `{skill-root}/steps-c/step-01b-resume.md`
+- **If V:** Load `{skill-root}/steps-v/step-01-validate.md`
+- **If E:** Load `{skill-root}/steps-e/step-01-assess.md`

--- a/src/workflows/testarch/bmad-testarch-trace/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-trace/SKILL.md
@@ -3,4 +3,13 @@ name: bmad-testarch-trace
 description: 'Generate traceability matrix and quality gate decision. Use when the user says "lets create traceability matrix" or "I want to analyze test coverage"'
 ---
 
-Follow the instructions in [workflow.md](workflow.md).
+## Conventions
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+
+## On Activation
+
+Read `{skill-root}/workflow.md` and follow it exactly.
+
+When `workflow.md`, step files, templates, or checklists reference sibling files with relative paths such as `steps-c/...`, `./instructions.md`, or `templates/...`, resolve them from `{skill-root}`, not from the workspace root.

--- a/src/workflows/testarch/bmad-testarch-trace/instructions.md
+++ b/src/workflows/testarch/bmad-testarch-trace/instructions.md
@@ -35,11 +35,11 @@ From `workflow.yaml`, resolve:
 ### 2. First Step
 
 Load, read completely, and execute:
-`./steps-c/step-01-load-context.md`
+`{skill-root}/steps-c/step-01-load-context.md`
 
 ### 3. Resume Support
 
 If the user selects **Resume** mode, load, read completely, and execute:
-`./steps-c/step-01b-resume.md`
+`{skill-root}/steps-c/step-01b-resume.md`
 
 This checks the output document for progress tracking frontmatter and routes to the next incomplete step.

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-01-load-context.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-01-load-context.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-load-context'
 description: 'Resolve coverage oracle, load knowledge base, and gather related artifacts'
-nextStepFile: './step-02-discover-tests.md'
+nextStepFile: '{skill-root}/steps-c/step-02-discover-tests.md'
 knowledgeIndex: './resources/tea-index.csv'
 outputFile: '{test_artifacts}/traceability-matrix.md'
 ---

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-02-discover-tests.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-02-discover-tests.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-02-discover-tests'
 description: 'Discover and catalog tests by level'
-nextStepFile: './step-03-map-criteria.md'
+nextStepFile: '{skill-root}/steps-c/step-03-map-criteria.md'
 outputFile: '{test_artifacts}/traceability-matrix.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-03-map-criteria.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-03-map-criteria.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-03-map-criteria'
 description: 'Map coverage oracle items to tests and build traceability matrix'
-nextStepFile: './step-04-analyze-gaps.md'
+nextStepFile: '{skill-root}/steps-c/step-04-analyze-gaps.md'
 outputFile: '{test_artifacts}/traceability-matrix.md'
 ---
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-04-analyze-gaps.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-04-analyze-gaps.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-04-analyze-gaps'
 description: 'Complete Phase 1 with adaptive orchestration (agent-team, subagent, or sequential)'
-nextStepFile: './step-05-gate-decision.md'
+nextStepFile: '{skill-root}/steps-c/step-05-gate-decision.md'
 outputFile: '{test_artifacts}/traceability-matrix.md'
 tempOutputFile: '/tmp/tea-trace-coverage-matrix-{{timestamp}}.json'
 ---

--- a/src/workflows/testarch/bmad-testarch-trace/steps-e/step-01-assess.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-e/step-01-assess.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-assess'
 description: 'Load an existing output for editing'
-nextStepFile: './step-02-apply-edit.md'
+nextStepFile: '{skill-root}/steps-e/step-02-apply-edit.md'
 ---
 
 # Step 1: Assess Edit Target

--- a/src/workflows/testarch/bmad-testarch-trace/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-v/step-01-validate.md
@@ -2,7 +2,7 @@
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
 outputFile: '{test_artifacts}/trace-validation-report.md'
-validationChecklist: '../checklist.md'
+validationChecklist: '{skill-root}/checklist.md'
 ---
 
 # Step 1: Validate Outputs

--- a/src/workflows/testarch/bmad-testarch-trace/workflow.md
+++ b/src/workflows/testarch/bmad-testarch-trace/workflow.md
@@ -12,6 +12,14 @@ web_bundle: true
 
 ---
 
+## PATH RESOLUTION
+
+- `{skill-root}` resolves to this workflow skill's installed directory.
+- `{project-root}` resolves to the repository working directory.
+- Resolve sibling workflow files such as `instructions.md`, `checklist.md`, `steps-c/...`, `steps-e/...`, `steps-v/...`, and templates from `{skill-root}`, not from the workspace root.
+
+---
+
 ## WORKFLOW ARCHITECTURE
 
 This workflow uses **tri-modal step-file architecture**:
@@ -35,9 +43,9 @@ This workflow uses **tri-modal step-file architecture**:
 
 ### 2. Route to First Step
 
-- **If C:** Load `steps-c/step-01-load-context.md`
-- **If R:** Load `steps-c/step-01b-resume.md`
-- **If V:** Load `steps-v/step-01-validate.md`
-- **If E:** Load `steps-e/step-01-assess.md`
+- **If C:** Load `{skill-root}/steps-c/step-01-load-context.md`
+- **If R:** Load `{skill-root}/steps-c/step-01b-resume.md`
+- **If V:** Load `{skill-root}/steps-v/step-01-validate.md`
+- **If E:** Load `{skill-root}/steps-e/step-01-assess.md`
 
 Create mode resolves the coverage oracle automatically in this order: formal requirements, contract/spec artifacts, resolvable external pointers (when `allow_external_pointer_resolution` is enabled), then synthetic journeys/requirements inferred from source (when `allow_synthetic_oracle` is enabled and no formal oracle exists).

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -268,6 +268,7 @@ async function runTests() {
     const skillMdPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/SKILL.md`);
     const workflowMdPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/workflow.md`);
     const workflowYamlPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/workflow.yaml`);
+    const instructionsMdPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/instructions.md`);
 
     if (await pathExists(skillMdPath)) {
       try {
@@ -317,6 +318,63 @@ async function runTests() {
         assert(!yamlContent.includes('_bmad/bmm/'), `${dirName} has no _bmad/bmm/ references`);
       } catch (error) {
         assert(false, `${dirName}/workflow.yaml validates`, error.message);
+      }
+    }
+
+    if (await pathExists(instructionsMdPath)) {
+      try {
+        const instructionsContent = await fs.readFile(instructionsMdPath, 'utf8');
+        assert(!instructionsContent.includes('`./steps-'), `${dirName}/instructions.md has no bare relative step references`);
+        assert(
+          instructionsContent.includes('`{skill-root}/steps-c/') ||
+            instructionsContent.includes('`{skill-root}/steps-v/') ||
+            instructionsContent.includes('`{skill-root}/steps-e/'),
+          `${dirName}/instructions.md anchors step entrypoints to {skill-root}`,
+        );
+      } catch (error) {
+        assert(false, `${dirName}/instructions.md validates`, error.message);
+      }
+    }
+
+    for (const stepDir of ['steps-c', 'steps-e', 'steps-v']) {
+      const stepDirPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/${stepDir}`);
+      if (!(await pathExists(stepDirPath))) continue;
+
+      const stepFiles = (await fs.readdir(stepDirPath)).filter((fileName) => fileName.endsWith('.md'));
+      for (const fileName of stepFiles) {
+        const stepPath = path.join(stepDirPath, fileName);
+        try {
+          const stepContent = await fs.readFile(stepPath, 'utf8');
+          const stepLabel = `${dirName}/${stepDir}/${fileName}`;
+
+          assert(!stepContent.includes("nextStepFile: './"), `${stepLabel} has no cwd-sensitive nextStepFile`);
+          if (stepContent.includes('nextStepFile:')) {
+            assert(/nextStepFile: '\{skill-root\}\/steps-[cev]\//.test(stepContent), `${stepLabel} anchors nextStepFile to {skill-root}`);
+          }
+
+          assert(!stepContent.includes("validationChecklist: '../checklist.md'"), `${stepLabel} has no relative validation checklist path`);
+          if (stepContent.includes('validationChecklist:')) {
+            assert(
+              stepContent.includes("validationChecklist: '{skill-root}/checklist.md'"),
+              `${stepLabel} anchors validationChecklist to {skill-root}`,
+            );
+          }
+
+          assert(!stepContent.includes("checklistFile: '../checklist.md'"), `${stepLabel} has no relative checklistFile path`);
+          if (stepContent.includes('checklistFile:')) {
+            assert(
+              stepContent.includes("checklistFile: '{skill-root}/checklist.md'"),
+              `${stepLabel} anchors checklistFile to {skill-root}`,
+            );
+          }
+
+          assert(!stepContent.includes("workflowPath: '../'"), `${stepLabel} has no relative workflowPath`);
+          if (stepContent.includes('workflowPath:')) {
+            assert(stepContent.includes("workflowPath: '{skill-root}'"), `${stepLabel} anchors workflowPath to {skill-root}`);
+          }
+        } catch (error) {
+          assert(false, `${dirName}/${stepDir}/${fileName} validates`, error.message);
+        }
       }
     }
   }

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -265,7 +265,47 @@ async function runTests() {
   };
 
   for (const [dirName, displayName] of Object.entries(workflowDirs)) {
+    const skillMdPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/SKILL.md`);
+    const workflowMdPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/workflow.md`);
     const workflowYamlPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/workflow.yaml`);
+
+    if (await pathExists(skillMdPath)) {
+      try {
+        const skillContent = await fs.readFile(skillMdPath, 'utf8');
+        assert(skillContent.includes('## On Activation'), `${dirName}/SKILL.md has On Activation section`);
+        assert(
+          skillContent.includes('Read `{skill-root}/workflow.md` and follow it exactly.'),
+          `${dirName}/SKILL.md loads workflow.md from {skill-root}`,
+        );
+        assert(
+          skillContent.includes('resolve them from `{skill-root}`, not from the workspace root'),
+          `${dirName}/SKILL.md explains workspace-root-safe relative path resolution`,
+        );
+        assert(!skillContent.includes('[workflow.md](workflow.md)'), `${dirName}/SKILL.md no longer uses a bare relative workflow link`);
+      } catch (error) {
+        assert(false, `${dirName}/SKILL.md validates`, error.message);
+      }
+    } else {
+      assert(false, `${dirName}/SKILL.md exists`, `src/workflows/testarch/${dirName}/SKILL.md not found`);
+    }
+
+    if (await pathExists(workflowMdPath)) {
+      try {
+        const workflowContent = await fs.readFile(workflowMdPath, 'utf8');
+        assert(workflowContent.includes('## PATH RESOLUTION'), `${dirName}/workflow.md documents path resolution`);
+        assert(
+          workflowContent.includes(
+            'Resolve sibling workflow files such as `instructions.md`, `checklist.md`, `steps-c/...`, `steps-e/...`, `steps-v/...`, and templates from `{skill-root}`, not from the workspace root.',
+          ),
+          `${dirName}/workflow.md explains sibling workflow path resolution`,
+        );
+        assert(/\{skill-root\}\/steps-[cev]\//.test(workflowContent), `${dirName}/workflow.md routes first step from {skill-root}`);
+      } catch (error) {
+        assert(false, `${dirName}/workflow.md validates`, error.message);
+      }
+    } else {
+      assert(false, `${dirName}/workflow.md exists`, `src/workflows/testarch/${dirName}/workflow.md not found`);
+    }
 
     if (await pathExists(workflowYamlPath)) {
       try {


### PR DESCRIPTION
## Summary

  Fix TEA workflow skill path resolution so installed skills do not depend on the current working directory.

  This hardens the workflow layer for runtimes like GitHub Copilot in VS Code, where slash-command execution can happen from the workspace root instead of the skill directory.

  Closes https://github.com/bmad-code-org/bmad-method-test-architecture-enterprise/issues/84

  ## What changed

  - Updated all 9 workflow launcher `SKILL.md` files to:
    - declare `{skill-root}` / `{project-root}` conventions
    - load `{skill-root}/workflow.md` explicitly
    - document that sibling workflow files must resolve from `{skill-root}`

  - Updated all workflow entry `workflow.md` files to:
    - document path resolution rules
    - anchor first-step routing to `{skill-root}/steps-*`

  - Hardened markdown-owned workflow references deeper in the step graph:
    - converted `nextStepFile: './...'` to `{skill-root}`-anchored paths
    - converted validation checklist references from `../checklist.md` to `{skill-root}/checklist.md`
    - converted teach-me-testing `workflowPath` references to `{skill-root}`
    - updated `instructions.md` files to stop advertising bare `./steps-*` paths

  - Added docs for custom authors and troubleshooting:
    - custom workflow authoring guidance for workspace-root runtimes
    - GitHub Copilot / VS Code troubleshooting entry for `No such file or directory` failures

  - Extended installation component tests to prevent regressions in:
    - workflow launcher path safety
    - workflow entrypoint path safety
    - step-to-step path safety
    - validation/checklist path safety

  ## Notes

  This PR intentionally does **not** change the machine-readable `workflow.yaml` component fields such as `instructions`, `validation`, or `template`, to avoid changing parser/runtime
  behavior without explicit engine validation.