### PR TITLE
fix: issue 104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `actions/setup-node@v6`
   - `actions/create-github-app-token@v3`
 - Publish releases now use `[Unreleased]` changelog notes before falling back to generated GitHub release notes when an exact version section is missing.
+- Documented workflow-local knowledge resources as intentional self-contained skill packaging and added validation for workflow-local knowledge indexes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,11 @@ TEA has two layers of files, and each has a specific job:
 | `steps-v/*.md`                                     | **Validate** steps — always 1 file: evaluate against checklist                                       | On demand                                               |
 | `checklist.md`                                     | Validation criteria — what "done" looks like for this workflow                                       | Read by steps-v                                         |
 | `*-template.md`                                    | Output skeleton with `{PLACEHOLDER}` vars — steps fill these in to produce the final artifact        | Read by steps-c when generating output                  |
-| `src/agents/bmad-tea/resources/tea-index.csv`      | Knowledge fragment index — id, name, tags, tier (core/extended/specialized), file path               | Read to decide which shared TEA fragments to load       |
+| `src/agents/bmad-tea/resources/tea-index.csv`      | Agent-level knowledge fragment index — id, name, tags, tier (core/extended/specialized), file path   | Read by the TEA agent for direct recommendations        |
+| `src/workflows/testarch/<workflow>/resources/`     | Workflow-local knowledge index and fragments                                                         | Read by workflow steps from that workflow's skill root  |
 | `resources/knowledge/*.md`                         | Reusable fragments — standards, patterns, API references                                             | Selectively read into context based on tier + config    |
+
+Workflow resource directories intentionally duplicate the TEA knowledge base. Each workflow skill must stay self-contained so it can be installed, copied, or invoked without reaching across skill boundaries. When knowledge changes, propagate the intended updates to the affected workflow resource directories instead of replacing them with a central runtime path.
 
 ```mermaid
 flowchart LR

--- a/docs/explanation/knowledge-base-system.md
+++ b/docs/explanation/knowledge-base-system.md
@@ -96,6 +96,8 @@ network-first,Network-First Safeguards,Intercept-before-navigate workflow,"netwo
 fixture-architecture,Fixture Architecture,Composable fixture patterns,"fixtures,architecture",knowledge/fixture-architecture.md
 ```
 
+The agent-level `resources/` directory is the reference catalog for Murat. Workflow skills also carry their own `resources/tea-index.csv` and `resources/knowledge/` directories. That duplication is intentional: workflow step frontmatter resolves `knowledgeIndex: './resources/tea-index.csv'` from `{skill-root}`, keeping each workflow skill modular and self-contained.
+
 **2. Workflow Loads Relevant Fragments**
 
 When user runs `atdd`:

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -24,6 +24,11 @@ async function pathExists(filePath) {
   }
 }
 
+function extractFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/);
+  return match ? match[1] : '';
+}
+
 // ANSI colors
 const colors = {
   reset: '\u001B[0m',
@@ -347,6 +352,7 @@ async function runTests() {
         const stepPath = path.join(stepDirPath, fileName);
         try {
           const stepContent = await fs.readFile(stepPath, 'utf8');
+          const frontmatter = extractFrontmatter(stepContent);
           const stepLabel = `${dirName}/${stepDir}/${fileName}`;
 
           assert(!stepContent.includes("nextStepFile: './"), `${stepLabel} has no cwd-sensitive nextStepFile`);
@@ -375,8 +381,8 @@ async function runTests() {
             assert(stepContent.includes("workflowPath: '{skill-root}'"), `${stepLabel} anchors workflowPath to {skill-root}`);
           }
 
-          if (stepContent.includes('knowledgeIndex:')) {
-            const knowledgeIndexMatch = stepContent.match(/^knowledgeIndex:\s*['"]([^'"]+)['"]/m);
+          if (frontmatter.includes('knowledgeIndex:')) {
+            const knowledgeIndexMatch = frontmatter.match(/^knowledgeIndex:\s*['"]([^'"]+)['"]/m);
             assert(Boolean(knowledgeIndexMatch), `${stepLabel} declares a parseable knowledgeIndex`);
 
             const knowledgeIndexReference = knowledgeIndexMatch ? knowledgeIndexMatch[1] : '';

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -12,6 +12,7 @@
 
 const path = require('node:path');
 const fs = require('node:fs/promises');
+const { parse } = require('csv-parse/sync');
 const yaml = require('js-yaml');
 
 async function pathExists(filePath) {
@@ -253,10 +254,12 @@ async function runTests() {
   ];
 
   for (const dirName of workflowDirs) {
+    const workflowDir = path.join(projectRoot, `src/workflows/testarch/${dirName}`);
     const skillMdPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/SKILL.md`);
     const customizeTomlPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/customize.toml`);
     const workflowYamlPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/workflow.yaml`);
     const instructionsMdPath = path.join(projectRoot, `src/workflows/testarch/${dirName}/instructions.md`);
+    let workflowKnowledgeIndexValidated = false;
 
     if (await pathExists(skillMdPath)) {
       try {
@@ -370,6 +373,46 @@ async function runTests() {
           assert(!stepContent.includes("workflowPath: '../'"), `${stepLabel} has no relative workflowPath`);
           if (stepContent.includes('workflowPath:')) {
             assert(stepContent.includes("workflowPath: '{skill-root}'"), `${stepLabel} anchors workflowPath to {skill-root}`);
+          }
+
+          if (stepContent.includes('knowledgeIndex:')) {
+            const knowledgeIndexMatch = stepContent.match(/^knowledgeIndex:\s*['"]([^'"]+)['"]/m);
+            assert(Boolean(knowledgeIndexMatch), `${stepLabel} declares a parseable knowledgeIndex`);
+
+            const knowledgeIndexReference = knowledgeIndexMatch ? knowledgeIndexMatch[1] : '';
+            const knowledgeIndexPath = path.resolve(workflowDir, knowledgeIndexReference);
+            const expectedKnowledgeIndexPath = path.join(workflowDir, 'resources', 'tea-index.csv');
+
+            assert(knowledgeIndexPath === expectedKnowledgeIndexPath, `${stepLabel} uses the workflow-local knowledge index`);
+            assert(await pathExists(knowledgeIndexPath), `${stepLabel} knowledgeIndex target exists`);
+
+            if (!workflowKnowledgeIndexValidated && (await pathExists(knowledgeIndexPath))) {
+              const records = parse(await fs.readFile(knowledgeIndexPath, 'utf8'), { columns: true, skip_empty_lines: true });
+              const workflowKnowledgeDir = path.join(path.dirname(knowledgeIndexPath), 'knowledge');
+              const workflowKnowledgeFiles = (await fs.readdir(workflowKnowledgeDir)).filter((name) => name.endsWith('.md'));
+              const missingFragments = [];
+
+              for (const record of records) {
+                if (!record.fragment_file) {
+                  missingFragments.push(`${record.id || '<missing-id>'}: missing fragment_file`);
+                  continue;
+                }
+
+                const fragmentPath = path.resolve(path.dirname(knowledgeIndexPath), record.fragment_file);
+                if (!(await pathExists(fragmentPath))) {
+                  missingFragments.push(record.fragment_file);
+                }
+              }
+
+              assert(
+                records.length === workflowKnowledgeFiles.length,
+                `${dirName}/resources/tea-index.csv line count matches workflow-local fragments`,
+                `Found ${records.length} records for ${workflowKnowledgeFiles.length} fragments`,
+              );
+              assert(missingFragments.length === 0, `${dirName}/resources/tea-index.csv fragment files exist`, missingFragments.join(', '));
+
+              workflowKnowledgeIndexValidated = true;
+            }
           }
         } catch (error) {
           assert(false, `${dirName}/${stepDir}/${fileName} validates`, error.message);


### PR DESCRIPTION
## Summary

- Clarifies that workflow-local TEA knowledge resources are intentional self-contained skill packaging.
- Adds install validation that workflow `knowledgeIndex` entries resolve to local indexes and fragment files.

Addresses #104.

## Validation

- `npm run test:install`
- `npm run test:knowledge`
- `npm run lint:md`
- `npm run format:check`
- `npm run lint`
- `npm run docs:validate-links`