### PR TITLE
Make TEA config defaults non-interactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- TEA-specific installer questions are now non-interactive defaults, with module config defaults mirrored in `src/agents/bmad-tea/customize.toml` for BMad customization/global config tooling.
+- TEA now defaults Playwright Utils, Pact.js Utils, Pact MCP, and browser automation integrations on (`tea_use_playwright_utils: true`, `tea_use_pactjs_utils: true`, `tea_pact_mcp: "mcp"`, `tea_browser_automation: "auto"`).
 - NFR workflow boundary clarified: `test-design` now owns NFR planning (thresholds, planned evidence, NFR-derived risks) and `nfr-assess` is reframed as NFR Evidence Audit — evaluating implementation evidence against planned thresholds after code exists.
 - `nfr-assess` step-02 now checks for an existing `test-design` NFR plan first and uses it as the primary threshold source, falling back to raw documents only for missing or UNKNOWN thresholds.
 - TEA agent menu gains a `GATE` routing intent that guides users through the release gate sequence (optional test-review → optional nfr-assess → trace Phase 2 gate) without merging those workflows.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ BMad workflows and Claude Code Skills solve different problems at different scal
 | **Context mgmt**  | Everything in one shot      | Just-in-time step loading, subagent isolation (separate contexts)            |
 | **Output**        | Freeform                    | Templates with `{PLACEHOLDER}` vars filled by specific steps                 |
 | **Validation**    | None                        | Dedicated mode (`steps-v/`) evaluating against checklists                    |
-| **Configuration** | None                        | `module.yaml` with prompted config flags driving conditional behavior        |
+| **Configuration** | None                        | `customize.toml` defaults plus `module.yaml` config metadata drive behavior  |
 | **Modes**         | None                        | Create / Edit / Validate — three separate step chains per workflow           |
 
 The key insight is that there is **no external runtime engine** — the LLM _is_ the engine. BMad workflows are structured markdown that the LLM follows as instructions: "read this file, execute it completely, save your output, load the next file." Skills are a single tool in a toolbox; BMad workflows are a workshop with a process manual.
@@ -151,13 +151,15 @@ npx bmad-method install
 
 ## Configuration
 
-TEA variables are defined in `src/module.yaml` and prompted during install:
+TEA variables have non-interactive defaults in `src/module.yaml` and
+`src/agents/bmad-tea/customize.toml`. BMad customize/global config tooling can
+override the `customize.toml` defaults without adding installer questions.
 
 - `test_artifacts` — base output folder for test artifacts
-- `tea_use_playwright_utils` — enable Playwright Utils integration (boolean)
-- `tea_use_pactjs_utils` — enable Pact.js Utils integration for contract testing when your project explicitly uses Pact (boolean)
-- `tea_pact_mcp` — SmartBear MCP for PactFlow/Broker interaction when broker integration is needed: mcp, none (string)
-- `tea_browser_automation` — browser automation mode: auto, cli, mcp, none (string)
+- `tea_use_playwright_utils` — enable Playwright Utils integration; defaults to `true`
+- `tea_use_pactjs_utils` — enable Pact.js Utils integration for contract testing; defaults to `true`
+- `tea_pact_mcp` — SmartBear MCP for PactFlow/Broker interaction; defaults to `mcp`
+- `tea_browser_automation` — browser automation mode: auto, cli, mcp, none; defaults to `auto`
 - `test_framework` — detected or configured test framework (Playwright, Cypress, Jest, Vitest, pytest, JUnit, Go test, dotnet test, RSpec)
 - `test_stack_type` — detected or configured stack type (frontend, backend, fullstack)
 - `ci_platform` — CI platform (auto, github-actions, gitlab-ci, jenkins, azure-devops, harness, circle-ci)

--- a/docs/explanation/tea-overview.md
+++ b/docs/explanation/tea-overview.md
@@ -370,7 +370,7 @@ Want to understand TEA principles and patterns in depth?
 Production-ready fixtures and utilities that enhance TEA workflows.
 
 - Install: `npm install -D @seontechnologies/playwright-utils`
-  > Note: Playwright Utils is enabled via the installer. Only set `tea_use_playwright_utils` in `_bmad/tea/config.yaml` if you need to override the installer choice.
+  > Note: Playwright Utils is enabled by default. Only set `tea_use_playwright_utils` in `_bmad/tea/config.yaml` if you need to override the default.
 - Impacts: `framework`, `atdd`, `automate`, `test-review`, `ci`
 - Utilities include: api-request, auth-session, network-recorder, intercept-network-call, recurse, log, file-utils, burn-in, network-error-monitor, fixtures-composition
 
@@ -379,7 +379,7 @@ Production-ready fixtures and utilities that enhance TEA workflows.
 Production-ready contract testing utilities that reduce raw Pact.js boilerplate and standardize provider verification patterns.
 
 - Install: `npm install -D @seontechnologies/pactjs-utils @pact-foundation/pact`
-- Config: `tea_use_pactjs_utils: true` (default is `false`, opt in only when you want Pact-aware workflows)
+- Config: `tea_use_pactjs_utils: true` (default is `true`; set it to `false` only when you want to suppress Pact-aware workflows)
 - Impacts: `framework`, `atdd`, `automate`, `test-design`, `test-review`, `ci`
 - Utilities include: createProviderState, toJsonMap, setJsonBody, setJsonContent, buildVerifierOptions, buildMessageVerifierOptions, createRequestFilter, noOpRequestFilter, handlePactBrokerUrlAndSelectors, getProviderVersionTags
 - Supports local monorepo flow (`pactUrls`) and remote broker flow (`PACT_BROKER_BASE_URL`, `PACT_BROKER_TOKEN`)
@@ -422,12 +422,14 @@ Optional MCP integration for design-time broker interaction in contract testing 
 
 **Configuration** (`_bmad/tea/config.yaml`):
 
-    tea_pact_mcp: "none"  # none | mcp
+    tea_pact_mcp: "mcp"  # none | mcp
 
 | Mode   | What happens                                                                                                        |
 | ------ | ------------------------------------------------------------------------------------------------------------------- |
 | `mcp`  | TEA can use SmartBear MCP tools for provider-state discovery, test review support, can-i-deploy, and matrix checks. |
-| `none` | Default. TEA skips broker/MCP integration entirely unless you explicitly enable it.                                 |
+| `none` | TEA skips broker/MCP integration entirely.                                                                          |
+
+If `mcp` is configured but the SmartBear MCP server or broker credentials are unavailable, TEA should continue without broker-assisted context and note the missing MCP capability in the workflow output.
 
 **Setup:**
 

--- a/docs/how-to/customization/integrate-playwright-utils.md
+++ b/docs/how-to/customization/integrate-playwright-utils.md
@@ -766,7 +766,7 @@ npm install -D @seontechnologies/playwright-utils
 
 **Causes:**
 
-1. Config not set: `tea_use_playwright_utils: false`
+1. Config disabled: `tea_use_playwright_utils: false`
 2. Workflow run before config change
 3. Package not installed
 

--- a/docs/how-to/workflows/setup-test-framework.md
+++ b/docs/how-to/workflows/setup-test-framework.md
@@ -94,7 +94,7 @@ TEA can integrate with `@seontechnologies/playwright-utils` for advanced fixture
 npm install -D @seontechnologies/playwright-utils
 ```
 
-Enable during BMad installation or set `tea_use_playwright_utils: true` in config.
+Playwright Utils is enabled by default in TEA config. Set `tea_use_playwright_utils: false` only when you need vanilla framework output.
 
 **Utilities available:** api-request, network-recorder, auth-session, intercept-network-call, recurse, log, file-utils, burn-in, network-error-monitor
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1077,11 +1077,11 @@ document_output_language: english
 3. Edit with your name and preferences
 4. Install dependencies:
    npm install
-5. Install playwright-utils when you want generated tests to use the default utility profile:
+5. Install playwright-utils to use the enabled-by-default utility fixtures:
    npm install -D @seontechnologies/playwright-utils
-6. Install pactjs-utils when you want generated tests to use the default contract-testing profile:
+6. Install pactjs-utils to use the enabled-by-default contract-testing patterns:
    npm install -D @seontechnologies/pactjs-utils @pact-foundation/pact
-7. Configure Pact MCP when your service uses PactFlow/Pact Broker:
+7. Install SmartBear MCP if your service uses PactFlow/Pact Broker:
    npm install -g @smartbear/mcp
 ```
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -9,13 +9,13 @@ Complete reference for all TEA (Test Engineering Architect) configuration option
 
 ## Configuration File Locations
 
-### User Configuration (Installer-Generated)
+### User Configuration (Generated/Resolved)
 
 **Location:** `_bmad/tea/config.yaml`
 
 **Purpose:** Project-specific configuration values for your repository
 
-**Created By:** BMad installer
+**Created By:** BMad installer and BMad customization tooling
 
 **Status:** Typically gitignored (user-specific values)
 
@@ -30,18 +30,18 @@ user_skill_level: intermediate
 output_folder: _bmad-output
 test_artifacts: _bmad-output/test-artifacts
 tea_use_playwright_utils: true
-tea_use_pactjs_utils: false
-tea_pact_mcp: 'none'
+tea_use_pactjs_utils: true
+tea_pact_mcp: 'mcp'
 tea_browser_automation: 'auto'
 tea_execution_mode: 'auto'
 tea_capability_probe: true
 ```
 
-### Canonical Schema (Source of Truth)
+### Canonical Schema Metadata
 
 **Location:** `src/module.yaml`
 
-**Purpose:** Defines available configuration keys, defaults, and installer prompts
+**Purpose:** Defines available configuration keys, non-interactive defaults, result transforms, and installer metadata
 
 **Created By:** BMAD maintainers (part of BMAD repo)
 
@@ -49,7 +49,13 @@ tea_capability_probe: true
 
 **Usage:** Reference only (do not edit unless contributing to BMAD)
 
-**Note:** The installer reads `module.yaml` to prompt for config values, then writes user choices to `_bmad/tea/config.yaml` in your project.
+**Note:** TEA-specific config keys are no longer installer questions. The installer can read `module.yaml` for defaults and result transforms, while BMad customize/global config tooling can override defaults from `customize.toml`.
+
+### Customization Defaults
+
+**Location:** `src/agents/bmad-tea/customize.toml`
+
+**Purpose:** Provides the module default values under `[config]` for BMad customize/global config tooling.
 
 ---
 
@@ -87,11 +93,7 @@ Enable Playwright Utils integration for production-ready fixtures and utilities.
 
 **Default:** `true`
 
-**Installer Prompt:**
-
-```
-Enable Playwright Utils integration?
-```
+**Installer Behavior:** Not prompted. Override through BMad customization or `_bmad/tea/config.yaml` when needed.
 
 **Purpose:** Enables TEA to:
 
@@ -143,13 +145,9 @@ Enable Pact.js Utils integration for production-ready consumer-driven contract t
 
 **Type:** `boolean`
 
-**Default:** `false`
+**Default:** `true`
 
-**Installer Prompt:**
-
-```
-Enable Pact.js Utils for consumer-driven contract testing?
-```
+**Installer Behavior:** Not prompted. Override through BMad customization or `_bmad/tea/config.yaml` when needed.
 
 **Purpose:** Enables TEA to:
 
@@ -168,7 +166,7 @@ Enable Pact.js Utils for consumer-driven contract testing?
 - `test-review` - Uses pactjs-utils provider/review patterns
 - `ci` - Adds contract-test stage and quality gates
 
-**Use this when:** your team already practices consumer-driven contract testing or wants TEA to scaffold Pact-aware patterns on purpose. Leave it off for projects that do not use Pact.
+**Use this when:** your team practices consumer-driven contract testing or wants TEA to scaffold Pact-aware patterns by default. Set it to `false` for projects that should avoid Pact-specific guidance.
 
 **Example (Enable):**
 
@@ -205,15 +203,11 @@ Pact MCP strategy for broker interaction during contract testing workflows.
 
 **Type:** `string`
 
-**Default:** `"none"`
+**Default:** `"mcp"`
 
 **Options:** `"mcp"` | `"none"`
 
-**Installer Prompt:**
-
-```
-Enable SmartBear MCP for PactFlow/Pact Broker? Only needed if you already use a broker.
-```
+**Installer Behavior:** Not prompted. Override through BMad customization or `_bmad/tea/config.yaml` when needed.
 
 **Purpose:** Controls whether TEA can use SmartBear MCP tools for:
 
@@ -228,7 +222,9 @@ Enable SmartBear MCP for PactFlow/Pact Broker? Only needed if you already use a 
 - `test-review` - MCP-assisted pact review context
 - `ci` - MCP can-i-deploy/matrix guidance references
 
-**Use this when:** your project already uses PactFlow or Pact Broker and you want TEA to query broker state during review, generation, or gate guidance. Otherwise leave it set to `none`.
+**Use this when:** your project uses PactFlow or Pact Broker and you want TEA to query broker state during review, generation, or gate guidance. Set it to `none` when broker interaction is not available.
+
+**Fallback:** If `tea_pact_mcp` is `"mcp"` but the SmartBear MCP server or broker credentials are unavailable, continue without broker-assisted context and note the missing MCP capability in the workflow output.
 
 **Prerequisites:**
 
@@ -275,11 +271,7 @@ Browser automation strategy for TEA workflows. Controls how TEA interacts with l
 
 **Options:** `"auto"` | `"cli"` | `"mcp"` | `"none"`
 
-**Installer Prompt:**
-
-```
-How should TEA interact with browsers during test generation?
-```
+**Installer Behavior:** Not prompted. Override through BMad customization or `_bmad/tea/config.yaml` when needed.
 
 **Purpose:** Controls which browser automation tool TEA uses:
 
@@ -354,11 +346,7 @@ Execution strategy for orchestration-capable TEA workflows.
 
 **Options:** `"auto"` | `"subagent"` | `"agent-team"` | `"sequential"`
 
-**Installer Prompt:**
-
-```
-How should TEA orchestrate multi-step generation and evaluation?
-```
+**Installer Behavior:** Not prompted. Override through BMad customization or `_bmad/tea/config.yaml` when needed.
 
 **Purpose:** Defines how TEA orchestrates worker-style steps in these workflows:
 
@@ -964,8 +952,8 @@ project_name: my-project
 user_skill_level: beginner # or intermediate/expert
 output_folder: _bmad-output
 tea_use_playwright_utils: true # Recommended
-tea_use_pactjs_utils: false # Recommended unless you actively use contract testing
-tea_pact_mcp: 'none' # Recommended unless you already use PactFlow/Broker
+tea_use_pactjs_utils: true # Recommended - Pact-aware patterns enabled by default
+tea_pact_mcp: 'mcp' # Recommended - broker/MCP guidance enabled when available
 tea_browser_automation: 'auto' # Recommended
 tea_execution_mode: 'auto' # Recommended - capability-aware mode selection
 tea_capability_probe: true # Recommended - fallback safely if mode unsupported
@@ -974,7 +962,8 @@ tea_capability_probe: true # Recommended - fallback safely if mode unsupported
 **Why recommended:**
 
 - Playwright Utils: Production-ready fixtures and utilities
-- Pact.js Utils: Leave disabled until the project explicitly needs contract testing
+- Pact.js Utils: Production-ready contract-testing guidance and scaffolding
+- Pact MCP: Broker-aware guidance when PactFlow/Pact Broker MCP is configured
 - Browser automation (auto): Smart CLI/MCP selection with fallback
 - Together: The three-part stack (see [Testing as Engineering](/docs/explanation/testing-as-engineering.md))
 
@@ -982,9 +971,8 @@ tea_capability_probe: true # Recommended - fallback safely if mode unsupported
 
 ```bash
 npm install -D @seontechnologies/playwright-utils
-# Optional contract-testing stack:
-# npm install -D @seontechnologies/pactjs-utils @pact-foundation/pact
-# npm install -g @smartbear/mcp
+npm install -D @seontechnologies/pactjs-utils @pact-foundation/pact
+npm install -g @smartbear/mcp
 npm install -g @playwright/cli@latest  # For CLI mode
 # Configure MCP servers in IDE (see Configure Browser Automation guide)
 ```
@@ -1026,8 +1014,8 @@ tea_capability_probe: true
 project_name: monorepo
 output_folder: _bmad-output
 tea_use_playwright_utils: true
-tea_use_pactjs_utils: false
-tea_pact_mcp: 'none'
+tea_use_pactjs_utils: true
+tea_pact_mcp: 'mcp'
 tea_execution_mode: 'auto'
 ```
 
@@ -1067,8 +1055,8 @@ project_knowledge: docs
 
 # TEA Configuration (Recommended baseline)
 tea_use_playwright_utils: true # Recommended - production-ready utilities
-tea_use_pactjs_utils: false # Opt in only if your service uses contract testing
-tea_pact_mcp: 'none' # Opt in only if your service uses PactFlow/Broker
+tea_use_pactjs_utils: true # Recommended - Pact-aware workflow guidance
+tea_pact_mcp: 'mcp' # Recommended - broker/MCP guidance when available
 tea_browser_automation: 'auto' # Recommended - smart CLI/MCP selection
 tea_execution_mode: 'auto' # Recommended - capability-aware team/subagent fallback
 tea_capability_probe: true # Recommended - safe fallback
@@ -1089,33 +1077,30 @@ document_output_language: english
 3. Edit with your name and preferences
 4. Install dependencies:
    npm install
-5. (Optional) Enable playwright-utils:
+5. Install playwright-utils when you want generated tests to use the default utility profile:
    npm install -D @seontechnologies/playwright-utils
-   Set tea_use_playwright_utils: true
-6. (Optional) Enable pactjs-utils:
+6. Install pactjs-utils when you want generated tests to use the default contract-testing profile:
    npm install -D @seontechnologies/pactjs-utils @pact-foundation/pact
-   Set tea_use_pactjs_utils: true
-7. (Optional) Enable Pact MCP:
+7. Configure Pact MCP when your service uses PactFlow/Pact Broker:
    npm install -g @smartbear/mcp
-   Set tea_pact_mcp: 'mcp'
 ```
 
 ---
 
-### Contract Testing Setup (Opt-In)
+### Contract Testing Setup
 
-Use this profile only for services that already use Pact or want TEA to scaffold contract-testing patterns on purpose.
-
-```yaml
-tea_use_pactjs_utils: true
-tea_pact_mcp: 'none' # Use 'mcp' only if you already use PactFlow/Broker
-```
-
-If you also use PactFlow or Pact Broker:
+TEA defaults to Pact-aware guidance. Use this profile for services that should keep contract-testing utilities and broker integration enabled.
 
 ```yaml
 tea_use_pactjs_utils: true
 tea_pact_mcp: 'mcp'
+```
+
+Disable broker interaction only when PactFlow/Pact Broker is not available:
+
+```yaml
+tea_use_pactjs_utils: true
+tea_pact_mcp: 'none'
 ```
 
 ---

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -385,36 +385,30 @@ If you are creating a custom TEA workflow, see [Extend TEA with Custom Workflows
 
 ## Configuration Issues
 
-### Variables Not Prompting During Installation
+### TEA Configuration Not Asked During Installation
 
-**Symptom**: Installation completes without asking for TEA configuration (test_artifacts, Playwright Utils, etc.).
+**Symptom**: Installation completes without asking for TEA configuration (test_artifacts, Playwright Utils, Pact.js Utils, etc.).
 
-**Causes**:
+**Cause**:
 
-- Variables marked as `prompt: false` in module.yaml
-- Installation running in non-interactive mode
-- Module.yaml misconfigured
+- This is expected. TEA-specific installer questions were removed; defaults now come from `src/module.yaml` and `src/agents/bmad-tea/customize.toml`.
 
 **Solutions**:
 
-1. Check variable prompt settings:
+1. Check the installed defaults:
 
    ```bash
    cat _bmad/tea/module.yaml | grep -A 3 "test_artifacts"
-   # Should show prompt: true
+   # Should show prompt: false and a default value
    ```
 
-2. Manually edit module.yaml if needed:
+2. Override project config if needed:
 
    ```bash
-   # Update _bmad/tea/module.yaml
-   vi _bmad/tea/module.yaml
+   vi _bmad/tea/config.yaml
    ```
 
-3. Run installation in interactive mode:
-   ```bash
-   npx bmad-method install --interactive
-   ```
+3. Use BMad customization tooling when available to override `customize.toml` defaults.
 
 ### Playwright Utils Integration Not Working
 

--- a/src/agents/bmad-tea/customize.toml
+++ b/src/agents/bmad-tea/customize.toml
@@ -4,6 +4,25 @@
 # identity of this agent. Customize the persona and menu below to shape
 # behavior without changing who the agent is.
 
+# Module configuration defaults. These mirror the non-interactive defaults in
+# src/module.yaml and are intended for BMad customize/global config tooling.
+
+[config]
+test_artifacts = "{output_folder}/test-artifacts"
+tea_use_playwright_utils = true
+tea_use_pactjs_utils = true
+tea_pact_mcp = "mcp"
+tea_browser_automation = "auto"
+tea_execution_mode = "auto"
+tea_capability_probe = true
+test_stack_type = "auto"
+ci_platform = "auto"
+test_framework = "auto"
+risk_threshold = "p1"
+test_design_output = "test-design"
+test_review_output = "test-reviews"
+trace_output = "traceability"
+
 [agent]
 # non-configurable skill frontmatter, create a custom agent if you need a new name/title
 name = "Murat"

--- a/src/module.yaml
+++ b/src/module.yaml
@@ -21,20 +21,22 @@ agents:
 ## project_root
 
 # TEA-specific configuration variables
+# These are non-interactive defaults. User-visible overrides live in
+# customize.toml/BMad customization tooling rather than installer questions.
 # IMPORTANT: tea_use_playwright_utils, tea_use_pactjs_utils, tea_pact_mcp, tea_browser_automation,
 # tea_execution_mode, tea_capability_probe, test_stack_type, ci_platform,
 # and test_framework are ACTIVELY USED in workflows
 # Other variables are FUTURE placeholders for Phase 10 enhancements
 
 test_artifacts:
-  prompt: "Where should test artifacts be stored? (test plans, coverage reports, quality audits)"
+  prompt: false
   default: "{output_folder}/test-artifacts"
   result: "{project-root}/{value}"
 
 # ✅ ACTIVELY USED - Playwright Utils integration (referenced in 6 workflows: automate, atdd, framework, test-design, test-review, ci)
 # CRITICAL: Must be boolean (true/false) not string - workflows check "if config.tea_use_playwright_utils: true"
 tea_use_playwright_utils:
-  prompt: "Enable Playwright Utils integration?"
+  prompt: false
   default: true
   result: "{value}"
   single-select:
@@ -46,8 +48,8 @@ tea_use_playwright_utils:
 # ✅ ACTIVELY USED - Pact.js Utils integration for contract testing (referenced in workflows: automate, atdd, framework, test-design, test-review, ci)
 # CRITICAL: Must be boolean (true/false) not string - workflows check "if config.tea_use_pactjs_utils: true"
 tea_use_pactjs_utils:
-  prompt: "Enable Pact.js Utils for consumer-driven contract testing?"
-  default: false
+  prompt: false
+  default: true
   result: "{value}"
   single-select:
     - value: true
@@ -59,8 +61,8 @@ tea_use_pactjs_utils:
 # Controls how TEA interacts with PactFlow/Pact Broker during test generation and review
 # CRITICAL: Must be a string value: "mcp" | "none"
 tea_pact_mcp:
-  prompt: "Enable SmartBear MCP for PactFlow/Pact Broker? Only needed if you already use a broker."
-  default: "none"
+  prompt: false
+  default: "mcp"
   result: "{value}"
   single-select:
     - value: "mcp"
@@ -72,7 +74,7 @@ tea_pact_mcp:
 # Controls how TEA interacts with live browsers during test generation
 # CRITICAL: Must be a string value: "auto" | "cli" | "mcp" | "none"
 tea_browser_automation:
-  prompt: "How should TEA interact with browsers during test generation?"
+  prompt: false
   default: "auto"
   result: "{value}"
   single-select:
@@ -89,7 +91,7 @@ tea_browser_automation:
 # Controls whether TEA runs orchestration steps sequentially, with subagents, or with agent teams
 # CRITICAL: Must be a string value: "auto" | "subagent" | "agent-team" | "sequential"
 tea_execution_mode:
-  prompt: "How should TEA orchestrate multi-step generation and evaluation?"
+  prompt: false
   default: "auto"
   result: "{value}"
   single-select:
@@ -105,7 +107,7 @@ tea_execution_mode:
 # ✅ ACTIVELY USED - Probe runtime capabilities before selecting execution mode
 # When true, TEA checks whether subagent/agent-team execution is actually supported and falls back safely.
 tea_capability_probe:
-  prompt: "Probe runtime capabilities before selecting execution mode?"
+  prompt: false
   default: true
   result: "{value}"
   single-select:
@@ -116,7 +118,7 @@ tea_capability_probe:
 
 # ✅ ACTIVELY USED - Stack type detection for multi-framework support
 test_stack_type:
-  prompt: "What type of project is this?"
+  prompt: false
   default: "auto"
   result: "{value}"
   single-select:
@@ -131,7 +133,7 @@ test_stack_type:
 
 # ✅ ACTIVELY USED - CI/CD platform detection
 ci_platform:
-  prompt: "Which CI/CD platform do you use?"
+  prompt: false
   default: "auto"
   result: "{value}"
   single-select:
@@ -154,7 +156,7 @@ ci_platform:
 
 # ✅ ACTIVELY USED - Test framework selection for multi-stack support
 test_framework:
-  prompt: "Which test framework are you using?"
+  prompt: false
   default: "auto"
   result: "{value}"
   single-select:
@@ -183,7 +185,7 @@ test_framework:
 
 # ⏭️ FUTURE - Risk threshold (not currently used in test-design workflow, marked for Phase 10)
 risk_threshold:
-  prompt: "What risk level requires mandatory testing?"
+  prompt: false
   default: "p1"
   result: "{value}"
   single-select:
@@ -199,17 +201,17 @@ risk_threshold:
 # ⏭️ FUTURE - Test output folders (not currently wired into workflows, marked for Phase 10)
 # IMPORTANT: test_artifacts already resolves to {project-root}/..., so don't re-prepend {project-root}
 test_design_output:
-  prompt: "Where should test design documents be stored?"
+  prompt: false
   default: "test-design"
   result: "{test_artifacts}/{value}"
 
 test_review_output:
-  prompt: "Where should test review reports be stored?"
+  prompt: false
   default: "test-reviews"
   result: "{test_artifacts}/{value}"
 
 trace_output:
-  prompt: "Where should traceability reports be stored?"
+  prompt: false
   default: "traceability"
   result: "{test_artifacts}/{value}"
 

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -29,6 +29,18 @@ function extractFrontmatter(content) {
   return match ? match[1] : '';
 }
 
+function extractTomlTable(content, tableName) {
+  const tablePattern = new RegExp(`^\\[${tableName}]\\s*$`, 'm');
+  const tableMatch = tablePattern.exec(content);
+  if (!tableMatch) return '';
+
+  const tableStart = tableMatch.index + tableMatch[0].length;
+  const remainingContent = content.slice(tableStart);
+  const nextTableMatch = /^\s*\[[^\]]+]\s*$/m.exec(remainingContent);
+
+  return nextTableMatch ? remainingContent.slice(0, nextTableMatch.index) : remainingContent;
+}
+
 // ANSI colors
 const colors = {
   reset: '\u001B[0m',
@@ -156,13 +168,14 @@ async function runTests() {
     // without adding a TOML dep.
     if (await pathExists(customizePath)) {
       const customizeContent = await fs.readFile(customizePath, 'utf8');
+      const configBlock = extractTomlTable(customizeContent, 'config');
 
       assert(customizeContent.includes('[agent]'), 'customize.toml has [agent] section');
-      assert(customizeContent.includes('[config]'), 'customize.toml has [config] defaults section');
-      assert(/^\s*tea_use_playwright_utils\s*=\s*true/m.test(customizeContent), 'customize.toml defaults Playwright Utils on');
-      assert(/^\s*tea_use_pactjs_utils\s*=\s*true/m.test(customizeContent), 'customize.toml defaults Pact.js Utils on');
-      assert(/^\s*tea_pact_mcp\s*=\s*"mcp"/m.test(customizeContent), 'customize.toml defaults Pact MCP on');
-      assert(/^\s*tea_browser_automation\s*=\s*"auto"/m.test(customizeContent), 'customize.toml defaults browser automation to auto');
+      assert(configBlock.length > 0, 'customize.toml has [config] defaults section');
+      assert(/^\s*tea_use_playwright_utils\s*=\s*true/m.test(configBlock), 'customize.toml [config] defaults Playwright Utils on');
+      assert(/^\s*tea_use_pactjs_utils\s*=\s*true/m.test(configBlock), 'customize.toml [config] defaults Pact.js Utils on');
+      assert(/^\s*tea_pact_mcp\s*=\s*"mcp"/m.test(configBlock), 'customize.toml [config] defaults Pact MCP on');
+      assert(/^\s*tea_browser_automation\s*=\s*"auto"/m.test(configBlock), 'customize.toml [config] defaults browser automation to auto');
       assert(/^\s*name\s*=\s*"Murat"/m.test(customizeContent), 'customize.toml pins agent.name = "Murat"');
       assert(/^\s*title\s*=\s*"Master Test Architect and Quality Advisor"/m.test(customizeContent), 'customize.toml pins agent.title');
       assert(/^\s*icon\s*=\s*"🧪"/m.test(customizeContent), 'customize.toml pins agent.icon');

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -81,16 +81,31 @@ async function runTests() {
     assert(moduleYaml.name === 'Test Architect', 'module.yaml has correct name');
     assert(typeof moduleYaml.description === 'string' && moduleYaml.description.length > 0, 'module.yaml has description');
     assert(typeof moduleYaml.default_selected === 'boolean', 'module.yaml has boolean default_selected');
-    assert(moduleYaml.tea_use_pactjs_utils.default === false, 'module.yaml defaults Pact.js Utils to false');
-    assert(moduleYaml.tea_pact_mcp.default === 'none', 'module.yaml defaults Pact MCP to none');
-    assert(
-      moduleYaml.tea_use_pactjs_utils.prompt.includes('consumer-driven contract testing'),
-      'module.yaml Pact.js Utils prompt explains CDC intent',
-    );
-    assert(
-      moduleYaml.tea_pact_mcp.prompt.includes('Only needed if you already use a broker'),
-      'module.yaml Pact MCP prompt explains broker prerequisite',
-    );
+    assert(moduleYaml.tea_use_playwright_utils.default === true, 'module.yaml defaults Playwright Utils to true');
+    assert(moduleYaml.tea_use_pactjs_utils.default === true, 'module.yaml defaults Pact.js Utils to true');
+    assert(moduleYaml.tea_pact_mcp.default === 'mcp', 'module.yaml defaults Pact MCP to mcp');
+    assert(moduleYaml.tea_browser_automation.default === 'auto', 'module.yaml defaults browser automation to auto');
+
+    const nonInteractiveConfigKeys = [
+      'test_artifacts',
+      'tea_use_playwright_utils',
+      'tea_use_pactjs_utils',
+      'tea_pact_mcp',
+      'tea_browser_automation',
+      'tea_execution_mode',
+      'tea_capability_probe',
+      'test_stack_type',
+      'ci_platform',
+      'test_framework',
+      'risk_threshold',
+      'test_design_output',
+      'test_review_output',
+      'trace_output',
+    ];
+    for (const key of nonInteractiveConfigKeys) {
+      assert(moduleYaml[key]?.prompt === false, `module.yaml does not prompt for ${key}`);
+      assert(moduleYaml[key]?.default !== undefined, `module.yaml keeps a default for ${key}`);
+    }
   } catch (error) {
     assert(false, 'module.yaml loads and validates', error.message);
   }
@@ -143,6 +158,11 @@ async function runTests() {
       const customizeContent = await fs.readFile(customizePath, 'utf8');
 
       assert(customizeContent.includes('[agent]'), 'customize.toml has [agent] section');
+      assert(customizeContent.includes('[config]'), 'customize.toml has [config] defaults section');
+      assert(/^\s*tea_use_playwright_utils\s*=\s*true/m.test(customizeContent), 'customize.toml defaults Playwright Utils on');
+      assert(/^\s*tea_use_pactjs_utils\s*=\s*true/m.test(customizeContent), 'customize.toml defaults Pact.js Utils on');
+      assert(/^\s*tea_pact_mcp\s*=\s*"mcp"/m.test(customizeContent), 'customize.toml defaults Pact MCP on');
+      assert(/^\s*tea_browser_automation\s*=\s*"auto"/m.test(customizeContent), 'customize.toml defaults browser automation to auto');
       assert(/^\s*name\s*=\s*"Murat"/m.test(customizeContent), 'customize.toml pins agent.name = "Murat"');
       assert(/^\s*title\s*=\s*"Master Test Architect and Quality Advisor"/m.test(customizeContent), 'customize.toml pins agent.title');
       assert(/^\s*icon\s*=\s*"🧪"/m.test(customizeContent), 'customize.toml pins agent.icon');
@@ -441,6 +461,31 @@ async function runTests() {
     );
   } catch (error) {
     assert(false, 'framework scaffold fragment list validates', error.message);
+  }
+
+  const pactConfigUsageChecks = [
+    {
+      label: 'ATDD preflight',
+      path: 'src/workflows/testarch/bmad-testarch-atdd/steps-c/step-01-preflight-and-context.md',
+    },
+    {
+      label: 'test-review context load',
+      path: 'src/workflows/testarch/bmad-testarch-test-review/steps-c/step-01-load-context.md',
+    },
+    {
+      label: 'CI pipeline generation',
+      path: 'src/workflows/testarch/bmad-testarch-ci/steps-c/step-02-generate-pipeline.md',
+    },
+  ];
+
+  for (const usageCheck of pactConfigUsageChecks) {
+    try {
+      const stepContent = await fs.readFile(path.join(projectRoot, usageCheck.path), 'utf8');
+      assert(stepContent.includes('tea_use_pactjs_utils'), `${usageCheck.label} references tea_use_pactjs_utils`);
+      assert(stepContent.includes('tea_pact_mcp'), `${usageCheck.label} references tea_pact_mcp`);
+    } catch (error) {
+      assert(false, `${usageCheck.label} Pact config usage validates`, error.message);
+    }
   }
 
   console.log('');


### PR DESCRIPTION
## Summary
- remove TEA-specific installer questions by marking module config entries as non-interactive defaults
- mirror TEA module defaults in the agent customize.toml [config] block for upcoming BMad customize/global config support
- default Playwright Utils, Pact.js Utils, Pact MCP, and browser automation integrations on, with docs and tests updated

## Notes
- Kept module.yaml single-select metadata for future UI/config tooling.
- Kept the existing test_artifacts result transform unchanged pending the BMad core installer contract.