### PR TITLE
fix: rename teach-me-testing completion certificate to completion summary

### DIFF
--- a/docs/explanation/tea-overview.md
+++ b/docs/explanation/tea-overview.md
@@ -42,7 +42,7 @@ BMad does not mandate TEA. There are five valid ways to use it (or skip it). Pic
 - Interactive learning companion that teaches testing progressively through 7 structured sessions.
 - Perfect for: QAs, developers learning testing, anyone wanting comprehensive testing knowledge.
 - **Time:** 1-2 weeks self-paced (30-90 min per session).
-- **Features:** State persistence (pause/resume), role-adapted examples (QA/Dev/Lead/VP), quiz validation, completion certificate.
+- **Features:** State persistence (pause/resume), role-adapted examples (QA/Dev/Lead/VP), quiz validation, completion summary.
 - **Command:** `teach-me-testing` or `TMT` in TEA agent.
 - See [Learn Testing with TEA Academy Tutorial](/docs/tutorials/learn-testing-tea-academy.md).
 

--- a/docs/how-to/workflows/teach-me-testing.md
+++ b/docs/how-to/workflows/teach-me-testing.md
@@ -39,7 +39,7 @@ Use TEA's `teach-me-testing` workflow (TEA Academy) to learn testing progressive
 - ✅ Testing fundamentals (risk-based, test pyramid, types)
 - ✅ TEA methodology (9 workflows, architecture patterns)
 - ✅ Practical skills (write your first good test)
-- ✅ Knowledge artifacts (session notes, completion certificate)
+- ✅ Knowledge artifacts (session notes, completion summary)
 - ✅ Confidence to apply TEA to your project
 
 ## Prerequisites
@@ -108,7 +108,7 @@ Your progress is automatically saved:
 
 - **Progress file:** `{test_artifacts}/teaching-progress/{your-name}-tea-progress.yaml`
 - **Session notes:** `{test_artifacts}/tea-academy/{your-name}/session-{N}-notes.md`
-- **Certificate:** `{test_artifacts}/tea-academy/{your-name}/tea-completion-certificate.md` (after all 7 sessions)
+- **Completion summary:** `{test_artifacts}/tea-academy/{your-name}/tea-completion-summary.md` (after all 7 sessions)
 
 ### Resuming Later
 
@@ -228,9 +228,9 @@ Skip fundamentals, focus on:
 **Resources:** All 42 knowledge fragments
 **GitHub:** [Knowledge Base Repository](https://github.com/bmad-code-org/bmad-method-test-architecture-enterprise/tree/main/src/agents/bmad-tea/resources/knowledge)
 
-## Completion Certificate
+## Completion Summary
 
-Complete all 7 sessions to receive your TEA Academy completion certificate with:
+Complete all 7 sessions to receive your TEA Academy completion summary with:
 
 - Session completion dates and scores
 - Average score across all sessions

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -48,7 +48,7 @@ All workflows listed here are current and supported in TEA, including `nfr-asses
 
 - Progress tracking file (`teaching-progress/{user}-tea-progress.yaml`)
 - Session notes for each completed session
-- Completion certificate (after all 7 sessions)
+- Completion summary (after all 7 sessions)
 - Learning artifacts (notes, test examples)
 
 **7 Sessions:**

--- a/docs/tutorials/learn-testing-tea-academy.md
+++ b/docs/tutorials/learn-testing-tea-academy.md
@@ -17,7 +17,7 @@ TEA Academy is an interactive learning companion that teaches testing through 7 
 - **Validates understanding:** Quiz after each session (≥70% to pass)
 - **Tracks progress:** Resume anytime with automatic state persistence
 - **Adapts to your role:** Examples customized for QA/Dev/Lead/VP
-- **Generates artifacts:** Session notes and completion certificate
+- **Generates artifacts:** Session notes and completion summary
 
 ## Quick Start
 
@@ -65,9 +65,9 @@ Each session:
 - Generates session notes
 - Saves progress automatically
 
-### 6. Earn Your Certificate
+### 6. Get Your Completion Summary
 
-Complete all 7 sessions to receive your TEA Academy completion certificate!
+Complete all 7 sessions to receive your TEA Academy completion summary!
 
 ## The 7 Sessions
 
@@ -188,7 +188,7 @@ All generated artifacts are saved:
         ├── session-02-notes.md
         ├── ...
         ├── session-07-notes.md
-        └── tea-completion-certificate.md    # Certificate (after all 7)
+        └── tea-completion-summary.md        # Completion summary (after all 7)
 ```
 
 ## Customization by Role
@@ -232,7 +232,7 @@ You can review the content and try again, or continue anyway. Your score is reco
 Yes! Run the workflow and select any session again. It will update your score.
 
 **Do I need to complete all 7 sessions?**
-For the completion certificate, yes. But you can learn from individual sessions anytime.
+For the completion summary, yes. But you can learn from individual sessions anytime.
 
 **Can multiple people use this?**
 Yes! Progress files are per-user. Each team member gets their own progress tracking.

--- a/src/workflows/testarch/bmad-teach-me-testing/checklist.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/checklist.md
@@ -24,7 +24,7 @@ Use this checklist to validate the teaching workflow meets quality standards.
 - [ ] Session status tracking fields present (not-started/in-progress/completed)
 - [ ] stepsCompleted array for continuation tracking
 - [ ] **session-notes-template.md** has all required sections
-- [ ] **certificate-template.md** includes all 7 sessions
+- [ ] **completion-summary-template.md** includes all 7 sessions
 
 ---
 
@@ -63,8 +63,8 @@ Use this checklist to validate the teaching workflow meets quality standards.
 ### Completion Step
 
 - [ ] **step-05-completion.md** verifies all 7 sessions complete
-- [ ] Certificate generated with accurate data
-- [ ] Final progress file update (certificate_generated: true)
+- [ ] Completion summary generated with accurate data
+- [ ] Final progress file update (summary_generated: true)
 - [ ] Congratulations message shown
 
 ---

--- a/src/workflows/testarch/bmad-teach-me-testing/data/curriculum.yaml
+++ b/src/workflows/testarch/bmad-teach-me-testing/data/curriculum.yaml
@@ -107,7 +107,7 @@ learning_paths:
       - session-07-advanced
     skip_optional:
       - session-01-quickstart # Can skip if already familiar
-    certificate_eligible_if_skipped: false
+    summary_eligible_if_skipped: false
 
   experienced:
     recommended_sequence:
@@ -119,11 +119,11 @@ learning_paths:
       - session-07-advanced
     skip_optional:
       - session-01-quickstart
-    certificate_eligible_if_skipped: false
+    summary_eligible_if_skipped: false
 
 # Completion Requirements
 completion:
-  minimum_sessions: 7 # All sessions required for certificate
+  minimum_sessions: 7 # All sessions required for completion summary
   passing_score: 70 # Minimum quiz score to pass session
-  average_score_threshold: 70 # Minimum average for certificate
-  certificate_note: "Certificate eligibility requires completion.minimum_sessions. If intermediate.skip_optional or experienced.skip_optional sessions are skipped, certificate eligibility is forfeited."
+  average_score_threshold: 70 # Minimum average for completion summary
+  summary_note: "Completion summary eligibility requires completion.minimum_sessions. If intermediate.skip_optional or experienced.skip_optional sessions are skipped, summary eligibility is forfeited."

--- a/src/workflows/testarch/bmad-teach-me-testing/instructions.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/instructions.md
@@ -79,7 +79,7 @@ Your progress is automatically saved after each session:
 
 - **Progress file:** `{test_artifacts}/teaching-progress/{your-name}-tea-progress.yaml`
 - **Session notes:** `{test_artifacts}/tea-academy/{your-name}/session-{N}-notes.md`
-- **Certificate:** `{test_artifacts}/tea-academy/{your-name}/tea-completion-certificate.md`
+- **Completion Summary:** `{test_artifacts}/tea-academy/{your-name}/tea-completion-summary.md`
 
 ## Quiz Scoring
 
@@ -89,7 +89,7 @@ Your progress is automatically saved after each session:
 
 ## Completion
 
-Complete all 7 sessions to receive your TEA Academy completion certificate with:
+Complete all 7 sessions to receive your TEA Academy completion summary with:
 
 - Session completion dates and scores
 - Skills acquired checklist

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-01-init.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-01-init.md
@@ -190,8 +190,8 @@ stepsCompleted: ['step-01-init']
 lastStep: 'step-01-init'
 lastContinued: { current_date }
 
-certificate_generated: false
-certificate_path: null
+summary_generated: false
+summary_path: null
 completion_date: null
 ---
 ```

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-03-session-menu.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-03-session-menu.md
@@ -142,7 +142,7 @@ Display:
 
 **Before displaying menu options, check:**
 
-If all 7 sessions have status 'completed' AND certificate_generated != true:
+If all 7 sessions have status 'completed' AND summary_generated != true:
 
 - Display: "🎉 **Congratulations!** You've completed all 7 sessions!"
 - Skip session menu options
@@ -185,7 +185,7 @@ What would you like to do?"
 
 Display:
 
-"**Proceeding to generate your completion certificate...**"
+"**Proceeding to generate your completion summary...**"
 
 Load, read entire file, then execute {completionFile}
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-07.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-04-session-07.md
@@ -199,7 +199,7 @@ Append 'step-04-session-07' to stepsCompleted.
 
 {If sessions_completed == 7:}
 🏆 **Congratulations!** You've completed ALL 7 sessions!
-Your completion certificate will be generated when you return to the menu.
+Your completion summary will be generated when you return to the menu.
 
 {Otherwise:}
 **Progress:** {completion_percentage}% complete ({sessions_completed} of 7 sessions)

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-05-completion.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-05-completion.md
@@ -1,17 +1,17 @@
 ---
 name: 'step-05-completion'
-description: 'Generate completion certificate, final progress update, congratulate learner'
+description: 'Generate completion summary, final progress update, congratulate learner'
 
 progressFile: '{test_artifacts}/teaching-progress/{user_name}-tea-progress.yaml'
-certificateTemplate: '../templates/certificate-template.md'
-certificateFile: '{test_artifacts}/tea-academy/{user_name}/tea-completion-certificate.md'
+summaryTemplate: '../templates/completion-summary-template.md'
+summaryFile: '{test_artifacts}/tea-academy/{user_name}/tea-completion-summary.md'
 ---
 
-# Step 5: Completion & Certificate Generation
+# Step 5: Completion & Summary Generation
 
 ## STEP GOAL:
 
-To generate the TEA Academy completion certificate, update final progress, and congratulate the learner on completing all 7 sessions.
+To generate the TEA Academy completion summary, update final progress, and congratulate the learner on completing all 7 sessions.
 
 ## MANDATORY EXECUTION RULES (READ FIRST):
 
@@ -30,19 +30,19 @@ To generate the TEA Academy completion certificate, update final progress, and c
 
 - 🎯 Focus on completion and celebration
 - 🚫 FORBIDDEN to proceed without verifying all 7 sessions complete
-- 💬 Approach: Congratulate, generate certificate, inspire next steps
+- 💬 Approach: Congratulate, generate completion summary, inspire next steps
 
 ## EXECUTION PROTOCOLS:
 
 - 🎯 Verify all sessions complete
-- 💾 Generate completion certificate
+- 💾 Generate completion summary
 - 📖 Final progress update
 - 🎉 This is the final step - no next step
 
 ## CONTEXT BOUNDARIES:
 
 - Available context: Progress file with all 7 sessions completed
-- Focus: Certificate generation and celebration
+- Focus: Summary generation and celebration
 - Dependencies: All 7 sessions must be complete
 
 ## MANDATORY SEQUENCE
@@ -63,7 +63,7 @@ Display:
 
 You still have {7 - sessions_completed} sessions remaining.
 
-Please return to the session menu to complete the remaining sessions before generating your certificate."
+Please return to the session menu to complete the remaining sessions before generating your completion summary."
 
 **THEN:** Stop and do not proceed. This is an error state.
 
@@ -116,15 +116,15 @@ You've completed all 7 sessions of TEA Academy!
 - Session 6 (Quality & Trace): {session_06_score}/100
 - Session 7 (Advanced Patterns): {session_07_score}/100
 
-Generating your completion certificate..."
+Generating your completion summary..."
 
-### 4. Generate Completion Certificate
+### 4. Generate Completion Summary
 
-Load {certificateTemplate} and create {certificateFile} with:
+Load {summaryTemplate} and create {summaryFile} with:
 
 ```markdown
 ---
-certificate_type: tea-academy-completion
+summary_type: tea-academy-completion
 user: { user_name }
 role: { role }
 completion_date: { current_date }
@@ -133,17 +133,13 @@ total_duration: { total_duration }
 average_score: { average_score }
 ---
 
-# 🏆 TEA Academy Completion Certificate
+# 🎓 TEA Academy Completion Summary
 
 ---
 
-## Certificate of Completion
+## {user_name}'s Learning Journey
 
-**This certifies that**
-
-# {user_name}
-
-**has successfully completed the TEA Academy testing curriculum**
+**{user_name} completed the TEA Academy testing curriculum**
 
 ---
 
@@ -227,10 +223,10 @@ All session notes and progress tracking available at:
 
 ---
 
-🧪 **Master Test Architect and Quality Advisor**
+🧪 **Keep building your testing craft.**
 ```
 
-Save certificate to {certificateFile}.
+Save summary to {summaryFile}.
 
 ### 5. Update Progress File (Final)
 
@@ -247,8 +243,8 @@ Load {progressFile} and make final updates:
 
 - `sessions_completed: 7`
 - `completion_percentage: 100`
-- `certificate_generated: true`
-- `certificate_path: '{certificateFile}'`
+- `summary_generated: true`
+- `summary_path: '{summaryFile}'`
 - `completion_date: {current_date}`
 
 **Update stepsCompleted:**
@@ -259,9 +255,9 @@ Load {progressFile} and make final updates:
 
 Save final progress file.
 
-### 6. Display Certificate
+### 6. Display Summary
 
-Display the complete certificate content to the user.
+Display the complete summary content to the user.
 
 ### 7. Final Celebration
 
@@ -276,11 +272,11 @@ You've successfully completed the entire TEA Academy curriculum!
 - ✅ 7 sessions completed
 - ✅ Average score: {average_score}/100
 - ✅ {total_duration} of dedicated learning
-- ✅ Certificate generated
+- ✅ Completion summary generated
 
 **All Your Artifacts:**
 
-- **Certificate:** {certificateFile}
+- **Completion Summary:** {summaryFile}
 - **Progress:** {progressFile}
 - **Session Notes:** {test_artifacts}/tea-academy/{user_name}/
 
@@ -318,10 +314,10 @@ Workflow ends here. User can run the workflow again to re-take sessions or explo
 
 ### ✅ SUCCESS:
 
-- All 7 sessions verified complete before certificate generation
+- All 7 sessions verified complete before summary generation
 - Average score calculated correctly
-- Certificate generated with all session data
-- Certificate saved to file
+- Summary generated with all session data
+- Summary saved to file
 - Progress file updated with completion status
 - Final celebration message displayed
 - All artifacts paths provided to user
@@ -329,14 +325,14 @@ Workflow ends here. User can run the workflow again to re-take sessions or explo
 
 ### ❌ SYSTEM FAILURE:
 
-- Generating certificate without verifying all sessions complete
+- Generating summary without verifying all sessions complete
 - Incorrect average score calculation
-- Missing session data in certificate
+- Missing session data in summary
 - Not updating progress file with completion status
 - Not providing artifact paths to user
 - Proceeding to next step (this is final - no next step)
 
-**Master Rule:** Verify completion, generate certificate, celebrate achievement, end workflow. This is the finale.
+**Master Rule:** Verify completion, generate completion summary, celebrate achievement, end workflow. This is the finale.
 
 ## On Complete
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-e/step-e-01-assess-workflow.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-e/step-e-01-assess-workflow.md
@@ -84,7 +84,7 @@ Ask targeted questions based on their response:
 
 - Progress template?
 - Session notes template?
-- Certificate template?
+- Completion summary template?
 - What fields need changing?
 
 **If editing data files:**

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
@@ -81,7 +81,7 @@ Report findings: Pass/Fail for each check.
 - [ ] Session status fields present
 - [ ] stepsCompleted array present
 - [ ] session-notes-template.md has required sections
-- [ ] certificate-template.md includes all 7 sessions
+- [ ] completion-summary-template.md includes all 7 sessions
 
 Report findings.
 

--- a/src/workflows/testarch/bmad-teach-me-testing/templates/completion-summary-template.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/templates/completion-summary-template.md
@@ -1,5 +1,5 @@
 ---
-certificate_type: tea-academy-completion
+summary_type: tea-academy-completion
 user: { { user_name } }
 role: { { role } }
 completion_date: { { completion_date } }
@@ -8,17 +8,13 @@ total_duration: { { total_duration } }
 average_score: { { average_score } }
 ---
 
-# 🏆 TEA Academy Completion Certificate
+# 🎓 TEA Academy Completion Summary
 
 ---
 
-## Certificate of Completion
+## {{user_name}}'s Learning Journey
 
-**This certifies that**
-
-## {{user_name}}
-
-**has successfully completed the TEA Academy testing curriculum**
+**{{user_name}} completed the TEA Academy testing curriculum**
 
 ---
 
@@ -83,4 +79,4 @@ All session notes and progress tracking available at:
 
 ---
 
-🧪 **Master Test Architect and Quality Advisor**
+🧪 **Keep building your testing craft.**

--- a/src/workflows/testarch/bmad-teach-me-testing/templates/progress-template.yaml
+++ b/src/workflows/testarch/bmad-teach-me-testing/templates/progress-template.yaml
@@ -89,7 +89,7 @@ stepsCompleted: []
 lastStep: ""
 lastContinued: ""
 
-# Completion Certificate
-certificate_generated: false
-certificate_path: null
+# Completion Summary
+summary_generated: false
+summary_path: null
 completion_date: null

--- a/src/workflows/testarch/bmad-teach-me-testing/workflow-plan-teach-me-testing.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/workflow-plan-teach-me-testing.md
@@ -371,7 +371,7 @@ teach-me-testing/
 ├── templates/                               # Document templates
 │   ├── progress-template.yaml
 │   ├── session-notes-template.md
-│   └── certificate-template.md
+│   └── completion-summary-template.md
 │
 ├── instructions.md
 └── checklist.md
@@ -488,17 +488,17 @@ teach-me-testing/
 
 ```
 teach-me-testing/
-├── workflow.md                           ✓ Created
-├── steps-c/                              ✓ Created (empty, to be populated)
-├── steps-e/                              ✓ Created (empty, to be populated)
-├── steps-v/                              ✓ Created (empty, to be populated)
-├── data/                                 ✓ Created (empty, to be populated)
-├── templates/                            ✓ Created
-│   ├── progress-template.yaml            ✓ Created
-│   ├── session-notes-template.md         ✓ Created
-│   └── certificate-template.md           ✓ Created
-├── instructions.md                       ✓ Created
-└── checklist.md                          ✓ Created
+├── workflow.md                            ✓ Created
+├── steps-c/                               ✓ Created (empty, to be populated)
+├── steps-e/                               ✓ Created (empty, to be populated)
+├── steps-v/                               ✓ Created (empty, to be populated)
+├── data/                                  ✓ Created (empty, to be populated)
+├── templates/                             ✓ Created
+│   ├── progress-template.yaml             ✓ Created
+│   ├── session-notes-template.md          ✓ Created
+│   └── completion-summary-template.md     ✓ Created
+├── instructions.md                        ✓ Created
+└── checklist.md                           ✓ Created
 ```
 
 **Location:** {external-project-root}/\_bmad-output/bmb-creations/workflows/teach-me-testing/
@@ -507,7 +507,7 @@ teach-me-testing/
 
 - Workflow name: teach-me-testing
 - Continuable: Yes (multi-session learning)
-- Document output: Yes (Progress YAML, Session notes MD, Certificate MD)
+- Document output: Yes (Progress YAML, Session notes MD, Completion Summary MD)
 - Mode: Tri-modal (Create + Edit + Validate)
 - Module: TEA (Test Architecture Enterprise)
 
@@ -533,8 +533,8 @@ teach-me-testing/
    - Quiz results
    - Practical examples
 
-4. **templates/certificate-template.md**
-   - Completion certificate structure
+4. **templates/completion-summary-template.md**
+   - Completion summary structure
    - All 7 sessions with scores
    - Skills acquired checklist
    - Learning artifacts paths
@@ -889,7 +889,7 @@ teach-me-testing/
 
 - progress-template.yaml
 - session-notes-template.md
-- certificate-template.md
+- completion-summary-template.md
 
 ### CREATE Mode (12 step files)
 


### PR DESCRIPTION
Renames the teach-me-testing "completion certificate" to "completion summary" throughout: template (`certificate-template.md` → `completion-summary-template.md`), step-05-completion, progress/curriculum yaml fields, checklist, and 4 docs pages. Same content (scores, skills acquired, next steps) — just no certifying language ("Certificate of Completion", "This certifies that").

Left `workflow-plan-teach-me-testing.md` (the original build-planning record) and unrelated compliance/TLS "certificate" mentions elsewhere untouched — different domain, not this workflow's output.

`npm test`, `docs:validate-links`, `docs:build` all green locally; `test:cli` running in CI.