### PR TITLE
fix: invoke the customization resolver with uv run

### DIFF
--- a/docs/how-to/customization/extend-tea-with-custom-workflows.md
+++ b/docs/how-to/customization/extend-tea-with-custom-workflows.md
@@ -75,7 +75,7 @@ Use patterns like these:
 ```md
 Read `{skill-root}/workflow.md` and follow it exactly.
 Load `{skill-root}/steps-c/step-01-preflight.md`.
-Run: `python3 {skill-root}/scripts/resolve_customization.py --key inject`
+Run: `uv run {skill-root}/scripts/resolve_customization.py --key inject`
 Read `{project-root}/_bmad/tea/config.yaml`.
 ```
 
@@ -84,7 +84,7 @@ Avoid patterns like these:
 ```md
 Read `workflow.md`
 Load `steps-c/step-01-preflight.md`
-Run: `python3 scripts/resolve_customization.py --key inject`
+Run: `uv run scripts/resolve_customization.py --key inject`
 ```
 
 This keeps the same skill portable across Codex, Claude Code, GitHub Copilot, and other runtimes that install skills into different directories.

--- a/docs/reference/troubleshooting.md
+++ b/docs/reference/troubleshooting.md
@@ -227,7 +227,7 @@ See [Extend TEA with Custom Workflows](../how-to/customization/extend-tea-with-c
 **Symptom**: A workflow or custom skill launched through GitHub Copilot in VS Code fails with an error such as:
 
 ```text
-python3 scripts/resolve_customization.py ...
+uv run scripts/resolve_customization.py ...
 can't open file 'C:\path\to\workspace\scripts\resolve_customization.py': [Errno 2] No such file or directory
 ```
 
@@ -244,7 +244,7 @@ can't open file 'C:\path\to\workspace\scripts\resolve_customization.py': [Errno 
 ```md
 Read `{skill-root}/workflow.md`
 Load `{skill-root}/steps-c/step-01-preflight.md`
-Run: `python3 {skill-root}/scripts/resolve_customization.py --key inject`
+Run: `uv run {skill-root}/scripts/resolve_customization.py --key inject`
 Read `{project-root}/_bmad/tea/config.yaml`
 ```
 
@@ -253,7 +253,7 @@ Read `{project-root}/_bmad/tea/config.yaml`
 ```md
 Read `workflow.md`
 Load `steps-c/step-01-preflight.md`
-Run: `python3 scripts/resolve_customization.py --key inject`
+Run: `uv run scripts/resolve_customization.py --key inject`
 ```
 
 If you are creating a custom TEA workflow, see [Extend TEA with Custom Workflows](../how-to/customization/extend-tea-with-custom-workflows.md) and author it with `{skill-root}` / `{project-root}` from the start.

--- a/src/agents/bmad-tea/SKILL.md
+++ b/src/agents/bmad-tea/SKILL.md
@@ -20,7 +20,7 @@ You are Murat, the Master Test Architect and Quality Advisor. You lead risk-base
 
 ### Step 1: Resolve the Agent Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-teach-me-testing/SKILL.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/SKILL.md
@@ -25,7 +25,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-05-completion.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-05-completion.md
@@ -336,7 +336,7 @@ Workflow ends here. User can run the workflow again to re-take sessions or explo
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-e/step-e-02-apply-edits.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-e/step-e-02-apply-edits.md
@@ -123,7 +123,7 @@ The teach-me-testing workflow has been updated.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
@@ -265,7 +265,7 @@ Workflow is usable but could be improved.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-atdd/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-05-validate-and-complete.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-05-validate-and-complete.md
@@ -116,7 +116,7 @@ Report:
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-v/step-01-validate.md
@@ -68,7 +68,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-automate/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-automate/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-automate/steps-c/step-04-validate-and-summarize.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-c/step-04-validate-and-summarize.md
@@ -107,7 +107,7 @@ Write `{outputFile}` including:
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-automate/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-automate/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-v/step-01-validate.md
@@ -68,7 +68,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-ci/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-ci/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-ci/steps-c/step-04-validate-and-summary.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-c/step-04-validate-and-summary.md
@@ -93,7 +93,7 @@ Report:
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-ci/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-ci/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-v/step-01-validate.md
@@ -82,7 +82,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-framework/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-framework/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-framework/steps-c/step-05-validate-and-summary.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-c/step-05-validate-and-summary.md
@@ -94,7 +94,7 @@ Report:
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-framework/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-framework/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-v/step-01-validate.md
@@ -68,7 +68,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-nfr/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-05-generate-report.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-05-generate-report.md
@@ -109,7 +109,7 @@ Report:
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-v/step-01-validate.md
@@ -68,7 +68,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-05-generate-output.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-05-generate-output.md
@@ -231,7 +231,7 @@ Summarize:
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-v/step-01-validate.md
@@ -68,7 +68,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-review/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-04-generate-report.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-04-generate-report.md
@@ -115,7 +115,7 @@ Report:
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-v/step-01-validate.md
@@ -68,7 +68,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-trace/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-trace/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-05-gate-decision.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-05-gate-decision.md
@@ -674,7 +674,7 @@ Then append the gate decision summary (from section 5 above) to the end of the e
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-v/step-01-validate.md
@@ -68,7 +68,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 ## On Complete
 
-Run: `python3 {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 


### PR DESCRIPTION
Every workflow shelled out to a bare `python3` to run `_bmad/scripts/resolve_customization.py`.

That script declares `requires-python = ">=3.11"` and hard-exits below it, because `tomllib` is a 3.11 stdlib addition. On macOS without Homebrew or Ubuntu 22.04 — where `python3` is 3.10 — activation fell through to the skill's "if the script fails" path and hand-merged the TOML layers in-context. No error surfaced to the user.

`uv run` reads the script's own `requires-python` and provisions a matching interpreter, so whatever `python3` resolves to on PATH no longer matters.

## Changes

- **37 invocations** in `src/` — the agent plus all nine testarch workflows, following the regular `SKILL.md` + `steps-v/` + `steps-e/` + `steps-c/` shape
- **5 in `docs/`** — `reference/troubleshooting.md` and `how-to/customization/extend-tea-with-custom-workflows.md`

The docs five matter more than their count suggests: they are the extension guides, so anyone authoring a custom TEA workflow was copying the broken line on day one.

Only the leading `python3` token changes; every argument is untouched.

## Verification

`npm test` passes. No bare `python3 <script>.py` remains anywhere in the repo.

Left alone: `steps-c/step-01-preflight.md:89` (`pytest` / `python -m pytest`) — that detects the *user's* test runner, not a BMad script.

Part of an ecosystem-wide pass — the same fix is going into bmad-method, bmad-builder, creative-intelligence-suite, and game-dev-studio.