### PR TITLE
docs(changelog): add 1.22.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [1.22.0] - 2026-08-09
+
+### Fixed
+
+- All forty-two `resolve_customization.py` call sites are invoked with `uv run` instead of a bare `python3` (#120). The script declares `requires-python = ">=3.11"` and hard-exits below it, because `tomllib` is a 3.11 stdlib addition. On macOS without Homebrew or Ubuntu 22.04, where `python3` is 3.10, activation fell through to the skill's "if the script fails" path and hand-merged the TOML layers in-context — no error surfaced, so a run could resolve customization subtly wrong and look fine. `uv run` reads the script's own `requires-python` and provisions a matching interpreter, so whatever `python3` resolves to on your PATH no longer matters. Covers the agent, all nine testarch workflows, and their `steps-v`/`steps-e`/`steps-c` hooks.
+- The customization guidance in `docs/reference/troubleshooting.md` and `docs/how-to/customization/extend-tea-with-custom-workflows.md` uses `uv run` (#120). These are the extension guides, so every custom TEA workflow authored from them was reproducing the defect on day one.
+- Removed remaining certificate wording from the `bmad-teach-me-testing` plan doc, completing the rename to completion summary.
+
+### Requirements
+
+- `uv` is what you need; a system Python is not. TEA skills no longer invoke a bare interpreter. Install [`uv`](https://docs.astral.sh/uv/) and it provisions the right Python per script.
+
+---
+
 ## [1.16.0] - 2026-05-08
 
 ### Added


### PR DESCRIPTION
Release notes for **1.22.0**, covering #120 and the teach-me-testing wording cleanup.

## No marketplace bump here, deliberately

This repo already solves the problem I was asked to fix by hand.

`publish.yaml` has a **Sync marketplace version** step that rewrites `.claude-plugin/marketplace.json` from `package.json` at release time, and `test/test-release-metadata.js` fails the suite when the two disagree. Bumping the plugin to `1.22.0` manually broke the pre-commit hook immediately:

```
Release metadata validation failed:
- .claude-plugin/marketplace.json version 1.22.0 does not match package.json version 1.21.8.
```

So the file is untouched and the release workflow will set it. This is the pattern the other BMad module repos are missing — bmad-builder, creative-intelligence-suite, and game-dev-studio all drift, and in game-dev-studio's case that drift let a dead skill path survive a full release.

## Why a new section rather than promoting `[Unreleased]`

`[Unreleased]` has accumulated **53 bullets** and the file jumps straight from it to `[1.16.0]` — so 1.16.1 through 1.21.8 shipped without their own entries. Promoting that block wholesale would attribute six releases' worth of work to 1.22.0.

Instead this adds a `## [1.22.0] - 2026-08-09` section below `[Unreleased]`, which keeps Keep a Changelog's ordering intact. **The accumulated backlog is still there and still misattributed** — worth a separate pass to split it across the versions that actually shipped it, but that's not this PR.

## The entry

- All 42 `resolve_customization.py` call sites now use `uv run` (#120) — the agent, all nine testarch workflows and their `steps-v`/`steps-e`/`steps-c` hooks, plus the two docs extension guides
- Certificate wording removed from the `bmad-teach-me-testing` plan doc

The entry explains why the old form mattered: below Python 3.11 the resolver hard-exits on `tomllib`, and each skill's "if the script fails" path caught it and hand-merged the TOML layers in-context. Silent, not loud.

## Verification

`npm test` passes, including `test:release-metadata`. markdownlint and prettier pass.