### PR TITLE
fix: stop trusting the review agent to sample its own convention baseline

### DIFF
--- a/DESIGN-CRITERIA-REGISTRY.md
+++ b/DESIGN-CRITERIA-REGISTRY.md
@@ -293,3 +293,44 @@ published report-table row at all. That's an intentional design choice for the f
 three, not the fabrication bug, so `convention-baseline.js` still grounds all seven
 uniformly (future-proofing, and Notes prose can cite any of them), but the deduction
 schedule only reads three of the seven back.
+
+## 2026-08-10, same day: the summary line was never checked against the findings either
+
+Auditing the fix above for the same class of defect elsewhere turned up a second one,
+worse in effect: `parse-report.js` never read `## Critical Issues (Must Fix)` or
+`## Recommendations (Should Fix)` at all. It trusted the agent's own
+`**Total Violations**:` summary line and nothing else. Reproduced directly: a report
+can document a real, row-cited Critical finding (`.skip` on a whole suite, `**Row**:
+C1`, a location, a description) in full prose, and if the line beside it says
+`0 Critical, 0 High, 0 Medium, 0 Low`, the CLI computes **Approve, 100/100** — the
+documented finding is invisible to the gate that's supposed to act on it. Unlike the
+convention-baseline defect this is a Block-vs-Approve flip, not a false LOW.
+
+`lib/registry-rows.js` (new) reads `criteria-registry.md`'s row → severity map
+straight from the skill, and `parse-report.js`'s `verifyFindingSeverityCounts` counts
+the finding blocks actually documented and binds them to the summary line: the number
+of Critical findings must equal the Total Violations Critical count exactly, the
+number of P1 (High) findings under Recommendations must equal the High count exactly,
+and every cited `**Row**: <id>` must be a real row whose registry severity matches the
+finding's own declared Severity (severity is read from the row, never chosen — the
+registry's own rule 1, previously unenforced downstream).
+
+Scoped to Critical and High only, deliberately. `deriveRecommendation` only acts on
+those two (`critical > 0` → Block, `high > 0` → Request Changes); Medium/Low only ever
+add "Approve with Comments" regardless of count, so a miscount there doesn't flip a
+merge decision the way this one does. The scope decision also had a practical forcing
+function: doing this for all four severities meant rewriting every fixture in this
+suite that declares a nonzero Medium/Low count with matching finding-detail blocks,
+a much larger and lower-value change for the two severities that were never the risk.
+
+Fifteen of the pre-existing report fixtures under `test/fixtures/test-review-cli/reports/`
+declared nonzero Critical/High counts with no finding section behind them at all
+(minimal fixtures, written before this check existed, testing other parser behavior).
+Each now carries the minimum real content the check requires — `### N. Title`,
+`**Severity**:`, `**Row**:`, nothing else — so their pre-existing assertions (which
+depend on the exact declared counts, verified individually before touching any of
+them) stay intact. Two fixtures needed no change: `fenced-recommendation.md`'s
+apparent 9/9 was inside its own fenced decoy example and the real (fence-stripped)
+count was already 0/0; `critical-approve.md`'s Critical-with-Approve combination
+already throws via the pre-existing inconsistent-verdict check, before this one ever
+runs.

--- a/DESIGN-CRITERIA-REGISTRY.md
+++ b/DESIGN-CRITERIA-REGISTRY.md
@@ -236,3 +236,60 @@ Changes** on `HIGH > 0`.
 The score lands on the persona run's 85 and the verdict stays where the codex run put
 it. Treat that as a sanity check on the arithmetic, not as validation: one hand-worked
 example is not a measurement, which is what the harness is for.
+
+## 2026-08-10: the baseline was never actually being measured
+
+Motivated by couture-cast PR #106 (comment 5234513259, `tea-test-review.yml`,
+`--agent codex`), which fired four LOW `Priority Markers` violations citing
+`Convention: priorityMarkers (18 of 40 sampled)`. `grep -rlniE "['"@]P[0-3]['"@ :.]"`
+across the entire target repo found zero real matches — one incidental hit, a `'p1'`
+silhouette-profile-ID fixture, nothing that is actually a priority tag. The installed
+`test-quality.md` knowledge fragment the report cited as its criteria source doesn't
+mention "priority" at all. The codex run invented a plausible, specific fraction for a
+convention that has never once been used in that repository.
+
+§2b above already designed against exactly this — sample the corpus outside the
+review set, cap at 40, record `corpusSize`/`sampled`, fall back to
+`baselineUnavailable: true` when nothing can be measured, "guessing a convention is
+worse than admitting it wasn't measured" — but the design lived entirely in prose the
+agent was trusted to follow. Nothing forced the sampling to be a real Glob/Grep
+instead of a number that merely sounded right, and nothing downstream ever checked
+the claim: not one report fixture in this repo's own `test/fixtures/test-review-cli/`
+suite even included a `**Convention Baseline**:` line, and `parse-report.js` had no
+code path that looked for one.
+
+Same fix as the score and the recommendation before it: stop trusting the agent to
+compute a number the CLI can compute itself. `cli/lib/convention-baseline.js` now
+performs §2b's sampling deterministically — `git ls-files`, the review set excluded,
+ranked closest-first by directory distance, capped at 40 — and, for the five keys
+with a literal recognized form (`priorityMarkers`, `testIds`, `networkFirst`,
+`dataFactories`, `fixtures`), scans the real sampled files for it. `bddNaming` and
+`assertionStyle` get no mechanical signal (no single token separates "adopted" from
+"not" for a naming style or a dialect choice) and stay agent-judged; the
+sampled/corpusSize grounding still applies to them.
+
+The result travels into the prompt as a fixed fact, the same way the review set
+already does, and `parse-report.js`'s `verifyConventionBaseline` binds every
+`Convention: <key> (<adopted> of <sampled> sampled)` citation and the
+`**Convention Baseline**:` line to it, one direction strictly (the sampled/corpusSize
+counts must match exactly — they're 100% mechanical) and one direction only
+downward (a citation claiming nonzero adoption for a key the CLI's own scan found
+zero real occurrences of anywhere in the sampled corpus is rejected outright; a lower
+or judgment-based count is left alone, because a regex cannot know intent and was
+never used to force a number up). Applied to #106's actual corpus, this scan finds
+zero `priorityMarkers` signal too — the same zero grep found — so the fabricated
+`(18 of 40 sampled)` citation would now fail closed (exit 3) instead of reaching a PR
+comment. `test/test-test-review-cli.js` Test Suite 11 and the git-fixture additions to
+Suite 8 reproduce this end-to-end against a real temp git repo built to the same
+shape (real neighbor test files, zero real priority markers anywhere).
+
+Not fixed here, and worth naming: the "seven keys" §2b measures don't map onto the
+registry's Convention gate class evenly. Only three published criteria are actually
+Convention-gated (`priorityMarkers` → L2, `testIds` → L3, `bddNaming` → L5);
+`networkFirst`/`dataFactories`/`fixtures` deliberately became Applicability-gated
+instead (see "The baseline is measured before it is judged against" above —
+popularity shouldn't demote a navigation race), and `assertionStyle` → L7 has no
+published report-table row at all. That's an intentional design choice for the first
+three, not the fabrication bug, so `convention-baseline.js` still grounds all seven
+uniformly (future-proofing, and Notes prose can cite any of them), but the deduction
+schedule only reads three of the seven back.

--- a/cli/lib/build-prompt.js
+++ b/cli/lib/build-prompt.js
@@ -290,6 +290,13 @@ function buildPrompt({
     '- Every finding under "## Critical Issues (Must Fix)" and "## Recommendations (Should Fix)" carries a',
     '  "**Row**: <id>" line naming the criteria-registry row that produced it, beside its "**Location**:" line.',
     '  Severity is read from that row, so a finding with no row has no severity and belongs in prose instead.',
+    '  The CLI checks this: a cited row must be a real criteria-registry.md row, and its registry severity must match',
+    '  the finding\'s own "**Severity**:" line exactly. "## Critical Issues (Must Fix)" is Critical-only by contract.',
+    '- The number of findings actually documented under "## Critical Issues (Must Fix)" must equal the Critical count',
+    '  in "**Total Violations**:" exactly, and the number of P1 (High) findings documented under',
+    '  "## Recommendations (Should Fix)" must equal the High count exactly. The CLI counts the finding blocks itself',
+    '  and rejects a report whose summary line disagrees with what it actually documented — a Critical or High finding',
+    '  described in prose but left out of the summary line (or the reverse) is a broken report, not a clean one.',
     '- A "## Reviewed Files" section listing every file in the authoritative review set exactly once, one canonical',
     '  repo-relative path per line, with no other paths.',
     contextFiles.length > 0

--- a/cli/lib/build-prompt.js
+++ b/cli/lib/build-prompt.js
@@ -30,6 +30,70 @@ const path = require('node:path');
 const { MODULE_DEFAULTS } = require('./resolve-tea-config');
 
 /**
+ * Prompt lines stating step-02-discover-tests.md §2b's convention baseline as a
+ * fixed fact instead of an instruction to derive. Mirrors the FILES-block override
+ * immediately above it: "the CLI already did this deterministic step, don't repeat
+ * it, and don't diverge from the number it got."
+ *
+ * The literal report-line forms here ("N test files sampled outside the review
+ * set", "unavailable: <reason>", "Convention: <key> (<adopted> of <sampled>
+ * sampled)") are read verbatim by parse-report.js's verifyConventionBaseline. Per
+ * this file's own header comment, a strict parser check and its prompt statement
+ * change together — keep these two in sync by hand.
+ *
+ * @param {object} [conventionBaseline] - See buildPrompt's JSDoc.
+ * @returns {string[]}
+ */
+function conventionBaselinePromptLines(conventionBaseline) {
+  if (!conventionBaseline) {
+    return [];
+  }
+  if (conventionBaseline.baselineUnavailable) {
+    return [
+      "step-02-discover-tests.md §2b's convention baseline has already been computed for this run and could NOT be",
+      `measured: ${conventionBaseline.reason}. Do not sample, glob, or guess a baseline yourself; do not invent an`,
+      'adoption count or a "form" for any convention key. Every Convention-gated criterion (and any other row whose',
+      'Basis would otherwise cite a convention) must score "✅ PASS (n/a)" and its Notes must say the baseline could',
+      'not be measured, with the reason above. The "**Convention Baseline**:" line must read exactly:',
+      `unavailable: ${conventionBaseline.reason}`,
+      'No finding, Basis column, or Note anywhere in the report may cite a "Convention: <key> (<adopted> of <sampled>',
+      'sampled)" fraction for any key: there is no corpus to cite one against, and the CLI rejects a report that does.',
+      '',
+    ];
+  }
+  const conventionLines = Object.entries(conventionBaseline.conventions).flatMap(([key, measured]) => {
+    if (!measured.mechanical) {
+      return [`- ${key}: not mechanically pre-scanned; read the sampled files yourself and judge adoption per the criteria table.`];
+    }
+    return measured.mechanicalSignal
+      ? [
+          `- ${key}: mechanically scanned; at least one sampled file contains a recognized form. Read the sampled files`,
+          `  yourself to judge the true adopted count (0-${conventionBaseline.sampled}) and record the observed form.`,
+        ]
+      : [
+          `- ${key}: mechanically scanned across all ${conventionBaseline.sampled} sampled files; zero occurrences of any`,
+          '  recognized form were found. This convention MUST be reported as absent: adopted = 0. A report claiming ANY',
+          `  nonzero adoption for ${key} will be rejected — the CLI already read every sampled file and found nothing.`,
+        ];
+  });
+  return [
+    "step-02-discover-tests.md §2b's convention baseline has already been computed for this run. Do not sample, glob,",
+    'or guess this yourself — the corpus and the counts below came from actually reading the files named, not the',
+    'reviewed files themselves (sampling the review set to judge the review set would be circular).',
+    `- corpusSize: ${conventionBaseline.corpusSize}, sampled: ${conventionBaseline.sampled}`,
+    `The "**Convention Baseline**:" line must read exactly: ${conventionBaseline.sampled} test files sampled outside the review set`,
+    'Sampled files (read exactly these; do not substitute, add, or drop any):',
+    '---BEGIN CONVENTION CORPUS---',
+    JSON.stringify(conventionBaseline.sampledFiles, null, 2),
+    '---END CONVENTION CORPUS---',
+    'Wherever a finding, Basis column, or Note cites one of these keys, use exactly this form: "Convention: <key>',
+    `(<adopted> of <sampled> sampled)", with <sampled> always equal to ${conventionBaseline.sampled}.`,
+    ...conventionLines,
+    '',
+  ];
+}
+
+/**
  * Build the prompt bundle handed to the agent (or printed with --agent none).
  *
  * @param {object} options
@@ -58,6 +122,13 @@ const { MODULE_DEFAULTS } = require('./resolve-tea-config');
  *   only --test-glob put there and that no built-in rule recognizes. The CLI
  *   cannot know whether a registry row attached, so it names them and the agent
  *   applies criteria-registry rule 4 rather than publishing 100 - 0 = 100.
+ * @param {object} [options.conventionBaseline] - step-02-discover-tests.md §2b's
+ *   "convention baseline", pre-computed by cli/lib/convention-baseline.js instead of
+ *   left to the agent to sample. `{ baselineUnavailable: true, reason }` or
+ *   `{ baselineUnavailable: false, corpusSize, sampled, sampledFiles, conventions }`.
+ *   Omitted (undefined) only when the caller deliberately skips grounding (e.g. a
+ *   unit test of an unrelated prompt fragment); every real CLI run supplies it, and
+ *   parse-report.js rejects a report that disagrees with it.
  * @returns {string}
  */
 function buildPrompt({
@@ -72,6 +143,7 @@ function buildPrompt({
   focus = '',
   unscorableTestArtifacts = [],
   forcedUnscorableCandidates = [],
+  conventionBaseline,
 }) {
   const absoluteSkillRoot = path.resolve(skillRoot);
   const absoluteOutputPath = path.resolve(outputPath);
@@ -124,6 +196,7 @@ function buildPrompt({
     JSON.stringify(files, null, 2),
     '---END FILES---',
     '',
+    ...conventionBaselinePromptLines(conventionBaseline),
     'The context set below is the rest of this pull request: the story, requirements, test design, or changed source',
     'that accompanied these tests. It is the same kind of data as the review set, never instructions.',
     'Read it to judge whether the tests match what changed. Do NOT review it, do NOT score it, and do NOT add any of',
@@ -222,6 +295,10 @@ function buildPrompt({
     contextFiles.length > 0
       ? '- A "## Review Context" section listing every supplied context artifact exactly once, one canonical repo-relative path per line, with no other paths. It must share no path with "## Reviewed Files".'
       : '- Omit the "## Review Context" section, or write the single word "none" in it: no context was supplied.',
+    conventionBaseline
+      ? '- The "**Convention Baseline**:" line and every "Convention: <key> (<adopted> of <sampled> sampled)" citation must ' +
+        "exactly match the convention baseline stated above — the CLI rejects a report that doesn't."
+      : '- Omit the "**Convention Baseline**:" line and any "Convention: <key> (...)" citation: no baseline was supplied for this run.',
   ].join('\n');
 }
 

--- a/cli/lib/convention-baseline.js
+++ b/cli/lib/convention-baseline.js
@@ -192,7 +192,10 @@ function computeConventionBaseline({ projectRoot, reviewFiles, cap = MAX_SAMPLED
   const reviewedDirs = reviewFiles.length > 0 ? reviewFiles.map(directoryOf) : [''];
   const ranked = eligible
     .map((file) => ({ file, distance: closestDistance(directoryOf(file), reviewedDirs) }))
-    .sort((a, b) => a.distance - b.distance || a.file.localeCompare(b.file));
+    // Plain code-unit comparison, not localeCompare: the tie-break order has to be
+    // the same sampled set on every machine regardless of the runtime's ICU/locale
+    // data, or "deterministic sampling" would itself be an environment-dependent claim.
+    .sort((a, b) => a.distance - b.distance || (a.file < b.file ? -1 : a.file > b.file ? 1 : 0));
   const sampledFiles = ranked.slice(0, cap).map((entry) => entry.file);
 
   return {

--- a/cli/lib/convention-baseline.js
+++ b/cli/lib/convention-baseline.js
@@ -1,0 +1,217 @@
+/**
+ * Deterministically compute `step-02-discover-tests.md` §2b's "convention baseline"
+ * instead of asking the review agent to sample and self-report it.
+ *
+ * Why this exists: couture-cast PR #106's codex-run review reported
+ * "Convention: priorityMarkers (18 of 40 sampled)" against a repo that has zero
+ * real instances of a P0-P3 marker anywhere (verified with a repo-wide grep). The
+ * skill's own design (§2b) already anticipated and forbade exactly this — "Guessing
+ * a convention is worse than admitting it wasn't measured" — but nothing enforced
+ * it: the sampling was entirely delegated to the agent's prompt-following honor
+ * system, so a plausible-sounding number could be generated without a single file
+ * actually being read.
+ *
+ * Same fix as everywhere else in this CLI (the review set, the deduction score, the
+ * recommendation): whatever can be computed deterministically and cheaply is
+ * computed here, stated in the prompt as a fixed fact, and cross-checked against
+ * the report afterward (see parse-report.js's verifyConventionBaseline). The agent
+ * is never asked to produce a number this module can produce itself.
+ *
+ * Two tiers of grounding:
+ * - corpusSize / sampled / sampledFiles: 100% mechanical (git ls-files, isTestFile,
+ *   directory-distance ranking, a 40-file cap) — this is exactly step-02 §2b's
+ *   sampling rules, just executed by code instead of described in prose. A report
+ *   that cites a different sampled count, or a different corpus, is provably wrong
+ *   and rejected outright.
+ * - adopted counts for the five keys with a concrete, literal recognized form
+ *   (priorityMarkers, testIds, networkFirst, dataFactories, fixtures): a generous,
+ *   high-recall regex scan over the real sampled files' real content. This is not
+ *   claimed to be a precise semantic judgment — a regex cannot know intent — but it
+ *   gives a safe one-directional floor: when the scan finds ZERO occurrences of any
+ *   recognized form anywhere in the entire sampled corpus, the true adopted count is
+ *   zero with very high confidence (a looser scan finding nothing all but rules out
+ *   a careful reader finding something), so the report may never claim otherwise.
+ *   The two keys with no literal recognized form (bddNaming — a naming *style*, not
+ *   a token; assertionStyle — dialect consistency) get no mechanical signal and stay
+ *   fully agent-judged; only their sampled/corpusSize grounding applies. This is an
+ *   honest limitation, not an oversight: a regex loose enough to catch every BDD-ish
+ *   test name would also be loose enough to approve almost anything, which defeats
+ *   the point of a floor check.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const { isTestFile } = require('./changed-tests');
+
+// Same order as step-02-discover-tests.md §2b's "Conventions to measure" table and
+// criteria-registry.md's mapping table. Every consumer of this list (build-prompt,
+// parse-report, the tests) shares this one array so the seven keys cannot drift.
+const CONVENTION_KEYS = ['priorityMarkers', 'testIds', 'bddNaming', 'networkFirst', 'dataFactories', 'fixtures', 'assertionStyle'];
+
+const MAX_SAMPLED_FILES = 40;
+const MIN_CORPUS_TO_ATTEMPT = 1; // 0 eligible files outside the review set: nothing to sample at all.
+
+// One regex per mechanically-recognizable key, matched against a sampled file's raw
+// content (case-insensitive, no /g flag so repeated .test() calls carry no state).
+// Deliberately high-recall: a false positive here only ever makes the zero-signal
+// floor check more permissive (it stops treating a convention as unattested), never
+// less — see the module doc comment. The literal forms mirror the "Record as `form`"
+// examples in step-02-discover-tests.md's table.
+const MECHANICAL_DETECTORS = {
+  priorityMarkers: /(\[P[0-3]\]|@P[0-3]\b|['"`]@?P[0-3]['"`]|\bpriority\s*:\s*['"`]?P[0-3]\b)/i,
+  testIds: /(data-testid|data-test-id|getByTestId|test-id\s*=|testid\s*=)/i,
+  networkFirst:
+    /(interceptNetworkCall\s*\(|page\.route\s*\(|cy\.intercept\s*\(|waitForResponse\s*\(|waitForRequest\s*\(|route\.fulfill\s*\()/i,
+  dataFactories: /(\bbuild[A-Z]\w*\s*\(|\bFactory\s*\(|from\s+['"][^'"]*factories|\bfactories\/)/i,
+  fixtures: /(mergeTests\s*\(|test\.extend\s*\(|from\s+['"][^'"]*fixtures|merged-fixtures)/i,
+};
+
+const MECHANICAL_CONVENTION_KEYS = Object.keys(MECHANICAL_DETECTORS);
+// bddNaming and assertionStyle: no literal token distinguishes "adopted" from "not",
+// so no mechanical signal is offered for them. Grounded on sampled/corpusSize only.
+const JUDGMENT_ONLY_CONVENTION_KEYS = CONVENTION_KEYS.filter((key) => !MECHANICAL_CONVENTION_KEYS.includes(key));
+
+/**
+ * List every git-tracked file in the repo, repo-relative POSIX paths.
+ *
+ * @param {string} projectRoot
+ * @returns {string[]|null} File list, or null when git ls-files could not run
+ *   (not a git repo, or some other git failure) — treated as baseline-unavailable
+ *   by the caller rather than thrown, matching step-02's own "shallow clone with
+ *   nothing else checked out" fallback case.
+ */
+function listGitTrackedFiles(projectRoot) {
+  const result = spawnSync('git', ['-c', 'core.quotePath=false', 'ls-files', '-z'], { cwd: projectRoot, encoding: 'utf8' });
+  if (result.error || result.status !== 0) {
+    return null;
+  }
+  return result.stdout.split('\0').filter(Boolean);
+}
+
+/** The directory portion of a repo-relative POSIX path ('' for a root-level file). */
+function directoryOf(filePath) {
+  const normalized = filePath.replaceAll('\\', '/');
+  const index = normalized.lastIndexOf('/');
+  return index === -1 ? '' : normalized.slice(0, index);
+}
+
+/** Path-segment distance between two directories: segments not on their shared prefix, both sides counted. */
+function directoryDistance(dirA, dirB) {
+  const a = dirA.split('/').filter(Boolean);
+  const b = dirB.split('/').filter(Boolean);
+  let common = 0;
+  while (common < a.length && common < b.length && a[common] === b[common]) {
+    common++;
+  }
+  return a.length - common + (b.length - common);
+}
+
+/** Minimum directory distance from a candidate file to any reviewed file's directory. */
+function closestDistance(candidateDir, reviewedDirs) {
+  let min = Number.POSITIVE_INFINITY;
+  for (const reviewedDir of reviewedDirs) {
+    const distance = directoryDistance(candidateDir, reviewedDir);
+    if (distance < min) {
+      min = distance;
+    }
+  }
+  return min;
+}
+
+/**
+ * Mechanically measure adoption of the five literal-form conventions across the
+ * already-sampled files' real content.
+ *
+ * @param {object} options
+ * @param {string} options.projectRoot
+ * @param {string[]} options.sampledFiles - Repo-relative paths, already capped/ranked.
+ * @returns {object} One entry per CONVENTION_KEYS, `{ mechanical: false }` for the
+ *   two judgment-only keys, `{ mechanical: true, adopted, mechanicalSignal }` for
+ *   the rest. `mechanicalSignal` is `adopted > 0`, i.e. whether the scan found the
+ *   convention anywhere at all in the sampled corpus.
+ */
+function measureConventions({ projectRoot, sampledFiles }) {
+  const conventions = {};
+  for (const key of CONVENTION_KEYS) {
+    const detector = MECHANICAL_DETECTORS[key];
+    if (!detector) {
+      conventions[key] = { mechanical: false };
+      continue;
+    }
+    let adopted = 0;
+    for (const file of sampledFiles) {
+      let content;
+      try {
+        content = fs.readFileSync(path.join(projectRoot, file), 'utf8');
+      } catch {
+        continue; // unreadable file contributes no signal either way, not a crash
+      }
+      if (detector.test(content)) {
+        adopted++;
+      }
+    }
+    conventions[key] = { mechanical: true, adopted, mechanicalSignal: adopted > 0 };
+  }
+  return conventions;
+}
+
+function unavailable(reason) {
+  return { baselineUnavailable: true, reason, corpusSize: 0, sampled: 0, sampledFiles: [], conventions: {} };
+}
+
+/**
+ * Compute the convention baseline for a review run: the real corpus outside the
+ * review set, ranked closest-first by directory distance and capped at 40 (per
+ * step-02-discover-tests.md §2b's sampling rules), plus a mechanical adoption scan
+ * over the sampled files' real content.
+ *
+ * @param {object} options
+ * @param {string} options.projectRoot - Repo root (git ls-files runs here).
+ * @param {string[]} options.reviewFiles - The review set; excluded from sampling and
+ *   used as the distance anchor.
+ * @param {number} [options.cap] - Sample size cap (default 40, matching step-02).
+ * @returns {object} `{ baselineUnavailable: true, reason, ... }` when no corpus
+ *   exists outside the review set (or git ls-files failed), otherwise
+ *   `{ baselineUnavailable: false, corpusSize, sampled, sampledFiles, conventions }`.
+ */
+function computeConventionBaseline({ projectRoot, reviewFiles, cap = MAX_SAMPLED_FILES }) {
+  const tracked = listGitTrackedFiles(projectRoot);
+  if (tracked === null) {
+    return unavailable('could not list repository files (git ls-files failed; not a git repo, or a git error)');
+  }
+
+  const reviewSet = new Set(reviewFiles.map((file) => file.replaceAll('\\', '/')));
+  const eligible = tracked.filter((file) => isTestFile(file) && !reviewSet.has(file));
+  const corpusSize = eligible.length;
+  if (corpusSize < MIN_CORPUS_TO_ATTEMPT) {
+    return unavailable('no test files exist outside the review set to measure a house convention against');
+  }
+
+  const reviewedDirs = reviewFiles.length > 0 ? reviewFiles.map(directoryOf) : [''];
+  const ranked = eligible
+    .map((file) => ({ file, distance: closestDistance(directoryOf(file), reviewedDirs) }))
+    .sort((a, b) => a.distance - b.distance || a.file.localeCompare(b.file));
+  const sampledFiles = ranked.slice(0, cap).map((entry) => entry.file);
+
+  return {
+    baselineUnavailable: false,
+    reason: null,
+    corpusSize,
+    sampled: sampledFiles.length,
+    sampledFiles,
+    conventions: measureConventions({ projectRoot, sampledFiles }),
+  };
+}
+
+module.exports = {
+  computeConventionBaseline,
+  CONVENTION_KEYS,
+  MECHANICAL_CONVENTION_KEYS,
+  JUDGMENT_ONLY_CONVENTION_KEYS,
+  // Exposed for tests only: unit-test the pure helpers without shelling out to git.
+  directoryDistance,
+  directoryOf,
+  measureConventions,
+};

--- a/cli/lib/parse-report.js
+++ b/cli/lib/parse-report.js
@@ -57,6 +57,7 @@
 const path = require('node:path');
 
 const { CONVENTION_KEYS } = require('./convention-baseline');
+const { SEVERITY_ENUM } = require('./registry-rows');
 
 const RECOMMENDATION_ENUM = ['Approve', 'Approve with Comments', 'Request Changes', 'Block'];
 const RECOMMENDATION_LINE = /^[ \t]*(?:\*\*Recommendation\*\*:|\*\*Recommendation:\*\*|Recommendation:)[ \t]*([^\r\n]+?)[ \t]*$/m;
@@ -125,9 +126,18 @@ function stripFencedCodeBlocks(text) {
   return kept.join('\n');
 }
 
-/** Extract a level-2 section's text, up to the next level-2 heading or EOF. */
+/** Escape a literal string for interpolation into a RegExp source. */
+function escapeRegExp(literal) {
+  return literal.replaceAll(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+}
+
+/**
+ * Extract a level-2 section's text, up to the next level-2 heading or EOF.
+ * `heading` is a literal string (escaped internally), not a regex fragment: some
+ * real headings contain parens ("Critical Issues (Must Fix)").
+ */
 function extractSection(text, heading) {
-  const match = new RegExp(`^## ${heading}[ \\t]*$`, 'm').exec(text);
+  const match = new RegExp(`^## ${escapeRegExp(heading)}[ \\t]*$`, 'm').exec(text);
   if (!match) {
     return null;
   }
@@ -639,6 +649,136 @@ function verifyConventionBaseline(text, conventionBaselineContract) {
   }
 }
 
+const CRITICAL_ISSUES_HEADING = 'Critical Issues (Must Fix)';
+const RECOMMENDATIONS_HEADING = 'Recommendations (Should Fix)';
+const FINDING_HEADING_PATTERN = /^### /m;
+const FINDING_SEVERITY_LINE = /^\*\*Severity\*\*:\s*P([0-3])\s*\(([A-Za-z]+)\)/m;
+// Captures whatever token follows, valid-looking or not, so a fabricated ID (e.g.
+// "Z9") is reported as "not a real row" rather than misread as "no Row line at all".
+const FINDING_ROW_LINE = /^\*\*Row\*\*:\s*(\S+)/m;
+const ROW_ID_SHAPE = /^[CHML]\d+$/;
+const PRIORITY_TO_SEVERITY = { 0: 'Critical', 1: 'High', 2: 'Medium', 3: 'Low' };
+
+/** Split a section's text into its "### N. Title" finding blocks (empty when none). */
+function splitFindingBlocks(sectionText) {
+  if (!sectionText || !FINDING_HEADING_PATTERN.test(sectionText)) {
+    return [];
+  }
+  // The template's "No critical issues detected. ✅" / "No additional recommendations..."
+  // placeholder is plain prose with no "### " heading, so it never produces a block here;
+  // an empty array already represents "no findings" correctly.
+  return sectionText
+    .split(FINDING_HEADING_PATTERN)
+    .slice(1)
+    .map((body) => `### ${body}`);
+}
+
+/** Parse one finding block's declared Severity and Row citation. */
+function parseFinding(block) {
+  const severityMatch = block.match(FINDING_SEVERITY_LINE);
+  let severity = null;
+  if (severityMatch) {
+    const word = severityMatch[2];
+    const canonical = SEVERITY_ENUM.find((candidate) => candidate.toLowerCase() === word.toLowerCase());
+    // Only trust a P-number/word pair that agree with each other (per the template,
+    // P0 is always "(Critical)", never "(High)" attached to a P0 by mistake).
+    severity = canonical && PRIORITY_TO_SEVERITY[severityMatch[1]] === canonical ? canonical : null;
+  }
+  return {
+    severity,
+    rawSeverity: severityMatch ? severityMatch[0].replace(/^\*\*Severity\*\*:\s*/, '') : null,
+    rowMatch: block.match(FINDING_ROW_LINE),
+  };
+}
+
+/**
+ * Bind every finding actually documented under "## Critical Issues (Must Fix)" and
+ * "## Recommendations (Should Fix)" to the report's own "**Total Violations**:" line,
+ * and every cited "**Row**:" to a real criteria-registry.md row with the severity the
+ * finding claims. Scoped to Critical and High only — the two severities that actually
+ * change the CI verdict (`deriveRecommendation`: any Critical → Block, any High →
+ * Request Changes); Medium/Low only ever add "Approve with Comments" regardless of
+ * count, so a miscount there doesn't flip a merge decision the way this does.
+ *
+ * Why this exists: nothing here was ever checked before. A report could — and, in the
+ * defect this fixes, would — document a real, row-cited Critical finding in prose
+ * while its "**Total Violations**:" line claimed zero, and the CLI computed Approve
+ * at 100/100 from the summary line alone, never reading the finding it sat beside.
+ *
+ * @param {string} text - Fence-stripped report text.
+ * @param {{critical: number, high: number}} violations - Parsed Total Violations counts.
+ * @param {object|null} registryRowSeverities - cli/lib/registry-rows.js's row→severity
+ *   map, or null when unavailable (e.g. a bare test-fixture skill root with no
+ *   criteria-registry.md) — row IDs are still required and internally validated, but
+ *   the "does this row really exist, and is its real severity what the finding claims"
+ *   cross-check is skipped without it.
+ */
+function verifyFindingSeverityCounts(text, violations, registryRowSeverities) {
+  function findingsIn(heading) {
+    return splitFindingBlocks(extractSection(text, heading)).map(parseFinding);
+  }
+
+  function requireRow(finding, sectionLabel) {
+    if (!finding.rowMatch) {
+      unparseable(
+        `A finding under "## ${sectionLabel}" has no "**Row**:" line; every finding there must cite the criteria-registry ` +
+          'row that produced it, per the report contract',
+      );
+    }
+    const row = finding.rowMatch[1];
+    // Contract-free shape check: a token that isn't even <letter><digits> shaped is
+    // fabricated regardless of whether registry data is available to check further.
+    if (!ROW_ID_SHAPE.test(row)) {
+      unparseable(
+        `A finding under "## ${sectionLabel}" cites Row "${row}", which is not a criteria-registry row ID ` +
+          '(expected a shape like "C1", "H5", "M3", "L2")',
+      );
+    }
+    if (!registryRowSeverities) {
+      return row;
+    }
+    const rowSeverity = registryRowSeverities[row];
+    if (!rowSeverity) {
+      unparseable(`A finding under "## ${sectionLabel}" cites Row "${row}", which is not a row in criteria-registry.md`);
+    }
+    if (rowSeverity !== finding.severity) {
+      unparseable(
+        `A finding under "## ${sectionLabel}" cites Row "${row}" (registry severity ${rowSeverity}) but declares Severity ` +
+          `${finding.severity ?? finding.rawSeverity ?? '(unrecognized)'}; severity is read from the row, never chosen`,
+      );
+    }
+    return row;
+  }
+
+  const criticalFindings = findingsIn(CRITICAL_ISSUES_HEADING);
+  for (const finding of criticalFindings) {
+    if (finding.severity !== 'Critical') {
+      unparseable(
+        `A finding under "## ${CRITICAL_ISSUES_HEADING}" declares Severity ${finding.rawSeverity ?? '(missing)'} instead of ` +
+          `P0 (Critical); "## ${CRITICAL_ISSUES_HEADING}" is Critical-only by contract`,
+      );
+    }
+    requireRow(finding, CRITICAL_ISSUES_HEADING);
+  }
+  if (criticalFindings.length !== violations.critical) {
+    unparseable(
+      `Report "**Total Violations**:" declares ${violations.critical} Critical, but "## ${CRITICAL_ISSUES_HEADING}" documents ` +
+        `${criticalFindings.length} finding(s); the two must agree exactly`,
+    );
+  }
+
+  const highFindings = findingsIn(RECOMMENDATIONS_HEADING).filter((finding) => finding.severity === 'High');
+  for (const finding of highFindings) {
+    requireRow(finding, RECOMMENDATIONS_HEADING);
+  }
+  if (highFindings.length !== violations.high) {
+    unparseable(
+      `Report "**Total Violations**:" declares ${violations.high} High, but "## ${RECOMMENDATIONS_HEADING}" documents ` +
+        `${highFindings.length} High-severity finding(s); the two must agree exactly`,
+    );
+  }
+}
+
 /**
  * Compute the authoritative quality score from the template's deduction
  * ledger. The agent's published score is presentation data only.
@@ -807,6 +947,7 @@ function parseReport(reportText, runContract = {}) {
         'critical violations with an approve recommendation is an inconsistent verdict',
     );
   }
+  verifyFindingSeverityCounts(text, violations, runContract.registryRowSeverities ?? null);
 
   const qualityScore = deriveQualityScore(reportText, violations);
 
@@ -936,4 +1077,5 @@ module.exports = {
   CONTEXT_BASIS_ENUM,
   verifyConventionBaseline,
   parseConventionCitations,
+  verifyFindingSeverityCounts,
 };

--- a/cli/lib/parse-report.js
+++ b/cli/lib/parse-report.js
@@ -30,6 +30,18 @@
  * "## Excluded From Review Set": the disclosure is part of the contract, not a
  * courtesy the agent may drop.
  *
+ * A third, opt-in cross-check: when the run contract carries `conventionBaseline`
+ * (every real CLI run does; see cli/lib/convention-baseline.js), the report's
+ * "**Convention Baseline**:" line and every "Convention: <key> (<adopted> of
+ * <sampled> sampled)" citation anywhere in the text are bound to what the CLI
+ * actually measured over the real sampled files — never a number the agent
+ * produced on its own. This exists because a live codex run on couture-cast PR #106
+ * reported "Convention: priorityMarkers (18 of 40 sampled)" against a repo with
+ * zero real instances of that convention anywhere, and nothing downstream ever
+ * checked the claim: no fixture in this repo's own test suite even included a
+ * "Convention Baseline" line before this cross-check existed. See
+ * verifyConventionBaseline.
+ *
  * Two more fields, `keyStrengths` and `keyWeaknesses`, are extracted best-effort
  * from the Executive Summary's "### Key Strengths" / "### Key Weaknesses"
  * bullet lists for PR-comment display. These are not part of the strict schema
@@ -43,6 +55,8 @@
  */
 
 const path = require('node:path');
+
+const { CONVENTION_KEYS } = require('./convention-baseline');
 
 const RECOMMENDATION_ENUM = ['Approve', 'Approve with Comments', 'Request Changes', 'Block'];
 const RECOMMENDATION_LINE = /^[ \t]*(?:\*\*Recommendation\*\*:|\*\*Recommendation:\*\*|Recommendation:)[ \t]*([^\r\n]+?)[ \t]*$/m;
@@ -65,6 +79,16 @@ const BONUS_TOTAL_LINE = /^[ \t]*Total Bonus[ \t]*:[ \t]*\+[ \t]*(\d+)[ \t]*$/m;
 // red gate. The cell sign is optional because no observed table rendering keeps
 // it, and the label case drifts alongside the reflow.
 const BONUS_TOTAL_ROW = /^[ \t]*\|[ \t]*Total Bonus[ \t]*\|[ \t]*\+?[ \t]*(\d+)[ \t]*\|?[ \t]*$/im;
+// Required literal forms, matched verbatim against what build-prompt.js's
+// conventionBaselinePromptLines instructs the agent to write. Anchored full-line so
+// a report cannot bury an unmodeled qualifier in the one line the CLI treats as
+// ground truth for the whole baseline.
+const CONVENTION_BASELINE_LINE_SOURCE = String.raw`^[ \t]*\*\*Convention Baseline\*\*:[ \t]*([^\r\n]+?)[ \t]*$`;
+const CONVENTION_BASELINE_AVAILABLE_PATTERN = /^(\d+)\s*test files sampled outside the review set\.?$/i;
+const CONVENTION_BASELINE_UNAVAILABLE_PATTERN = /^unavailable:\s*(.+)$/i;
+// Not anchored to a section: a fabricated fraction is just as much a defect
+// whether it lands in the criteria table's Basis column or in prose Notes.
+const CONVENTION_CITATION_PATTERN = /Convention:\s*([A-Za-z]+)\s*\(\s*(\d+)\s*of\s*(\d+)\s*sampled\s*\)/gi;
 const SEVERITY_DEDUCTIONS = { critical: 10, high: 5, medium: 2, low: 1 };
 const MAX_BONUS = 30; // six bonus categories, worth 0 or 5 each
 // Both renderings of the two normalized ledger fields, line form first. Held as
@@ -500,6 +524,121 @@ function verifyRunContract({ reviewedFiles, contextBasis, contextFiles, excluded
   }
 }
 
+/** Extract every "Convention: <key> (<adopted> of <sampled> sampled)" citation in the report, wherever it appears. */
+function parseConventionCitations(text) {
+  return [...text.matchAll(CONVENTION_CITATION_PATTERN)].map((match) => ({
+    key: match[1],
+    adopted: Number.parseInt(match[2], 10),
+    sampled: Number.parseInt(match[3], 10),
+  }));
+}
+
+/** Extract the optional, at-most-one "**Convention Baseline**:" line's raw value. */
+function parseConventionBaselineLine(text) {
+  const matches = [...text.matchAll(new RegExp(CONVENTION_BASELINE_LINE_SOURCE, 'gm'))];
+  if (matches.length === 0) {
+    return null;
+  }
+  if (matches.length > 1) {
+    unparseable(`Report must contain at most one "**Convention Baseline**:" line; found ${matches.length}`);
+  }
+  return stripWrappers(matches[0][1]);
+}
+
+/**
+ * Bind every "Convention: <key> (<adopted> of <sampled> sampled)" citation, and the
+ * "**Convention Baseline**:" line, to what this run actually measured — never to a
+ * number the agent produced on its own. See this file's header comment for why.
+ *
+ * Two tiers, matching cli/lib/convention-baseline.js's own two tiers of confidence:
+ * - `sampled` (and the overall corpus size) is 100% mechanical, so any disagreement
+ *   is unconditionally rejected: a report cannot cite a corpus this run never sampled.
+ * - `adopted` is only checked one direction. The CLI's own scan over the real
+ *   sampled files is high-recall by design (see convention-baseline.js's doc
+ *   comment), so a report claiming a nonzero adopted count for a key the CLI found
+ *   zero real occurrences of is provably fabricated and rejected. A report claiming
+ *   a LOWER or equally-nonzero count than the CLI found is left to the agent's
+ *   judgment — a regex cannot know intent, so it is never used to force a number up.
+ *
+ * @param {string} text - Fence-stripped report text.
+ * @param {object} [conventionBaselineContract] - The run's cli/lib/convention-baseline.js
+ *   result, or undefined when the caller supplied no ground truth (e.g. a unit test
+ *   of an unrelated feature) — in that case only the cheap, contract-free sanity
+ *   checks below run (unrecognized key, adopted > sampled).
+ */
+function verifyConventionBaseline(text, conventionBaselineContract) {
+  const citations = parseConventionCitations(text);
+  for (const citation of citations) {
+    if (!CONVENTION_KEYS.includes(citation.key)) {
+      unparseable(`Report cites an unrecognized Convention key "${citation.key}"; expected one of: ${CONVENTION_KEYS.join(', ')}`);
+    }
+    if (citation.adopted > citation.sampled) {
+      unparseable(
+        `Report Convention citation "${citation.key}" claims ${citation.adopted} adopted of only ${citation.sampled} sampled, ` +
+          'which is impossible',
+      );
+    }
+  }
+
+  const baselineLineRaw = parseConventionBaselineLine(text);
+  if (!conventionBaselineContract) {
+    return;
+  }
+
+  if (conventionBaselineContract.baselineUnavailable) {
+    if (citations.length > 0) {
+      unparseable(
+        `Report cites Convention baseline fraction(s) (e.g. "${citations[0].key} (${citations[0].adopted} of ${citations[0].sampled} sampled)") ` +
+          `while this run recorded baselineUnavailable (${conventionBaselineContract.reason}); an unmeasurable baseline may never be cited as a ` +
+          'specific sampled fraction',
+      );
+    }
+    if (baselineLineRaw !== null && !CONVENTION_BASELINE_UNAVAILABLE_PATTERN.test(baselineLineRaw)) {
+      unparseable(
+        `Report "**Convention Baseline**:" line "${baselineLineRaw}" must read "unavailable: <reason>"; this run could not measure a ` +
+          `baseline (${conventionBaselineContract.reason})`,
+      );
+    }
+    return;
+  }
+
+  if (baselineLineRaw === null) {
+    unparseable('Report is missing the "**Convention Baseline**:" line; this run measured a real baseline and the report must state it');
+  }
+  const availableMatch = CONVENTION_BASELINE_AVAILABLE_PATTERN.exec(baselineLineRaw);
+  if (!availableMatch) {
+    unparseable(
+      `Report "**Convention Baseline**:" line "${baselineLineRaw}" does not match the required ` +
+        '"<N> test files sampled outside the review set" form',
+    );
+  }
+  const declaredSampled = Number.parseInt(availableMatch[1], 10);
+  if (declaredSampled !== conventionBaselineContract.sampled) {
+    unparseable(
+      `Report "**Convention Baseline**:" declares ${declaredSampled} sampled files, but this run actually sampled ` +
+        `${conventionBaselineContract.sampled} outside the review set`,
+    );
+  }
+
+  for (const citation of citations) {
+    if (citation.sampled !== conventionBaselineContract.sampled) {
+      unparseable(
+        `Report Convention citation "${citation.key}" cites ${citation.sampled} sampled files, but this run actually sampled ` +
+          `${conventionBaselineContract.sampled} outside the review set; a Convention row must be judged against the corpus this run ` +
+          'measured, never a different count',
+      );
+    }
+    const measured = conventionBaselineContract.conventions && conventionBaselineContract.conventions[citation.key];
+    if (measured && measured.mechanical && measured.mechanicalSignal === false && citation.adopted > 0) {
+      unparseable(
+        `Report Convention citation "${citation.key} (${citation.adopted} of ${citation.sampled} sampled)" claims adoption, but this run ` +
+          `scanned every one of the ${conventionBaselineContract.sampled} sampled files for the recognized forms and found zero occurrences; ` +
+          'a convention with no real evidence in the sampled corpus must be reported as absent (0 adopted), never a fabricated nonzero count',
+      );
+    }
+  }
+}
+
 /**
  * Compute the authoritative quality score from the template's deduction
  * ledger. The agent's published score is presentation data only.
@@ -697,6 +836,7 @@ function parseReport(reportText, runContract = {}) {
   }
 
   verifyRunContract({ reviewedFiles, contextBasis, contextFiles, excludedFiles }, runContract);
+  verifyConventionBaseline(text, runContract.conventionBaseline);
 
   const executiveSection = extractSection(text, 'Executive Summary');
   const keyStrengths = extractBullets(extractSubsection(executiveSection, 'Key Strengths'), '✅');
@@ -717,6 +857,13 @@ function parseReport(reportText, runContract = {}) {
     keyStrengths,
     keyWeaknesses,
   };
+  // Surfaced (not just used to gate) so a stored verdict JSON says what this run
+  // actually measured, the same reasoning as attaching agent/model: a fabricated
+  // baseline is invisible to a human reviewer unless the ground truth travels with
+  // the verdict, not just the pass/fail outcome of checking against it.
+  if (runContract.conventionBaseline) {
+    parsed.conventionBaseline = runContract.conventionBaseline;
+  }
   if (
     reportedQualityScore !== qualityScore ||
     (reportedQualityGrade !== undefined && reportedQualityGrade !== gradeForScore(qualityScore))
@@ -780,4 +927,13 @@ function scoreFails(score, minScore) {
   return score < minScore;
 }
 
-module.exports = { parseReport, normalizeReportScore, deriveRecommendation, verdictFor, scoreFails, CONTEXT_BASIS_ENUM };
+module.exports = {
+  parseReport,
+  normalizeReportScore,
+  deriveRecommendation,
+  verdictFor,
+  scoreFails,
+  CONTEXT_BASIS_ENUM,
+  verifyConventionBaseline,
+  parseConventionCitations,
+};

--- a/cli/lib/registry-rows.js
+++ b/cli/lib/registry-rows.js
@@ -1,0 +1,60 @@
+/**
+ * Load the criteria-registry.md row → severity map from the skill itself, so the
+ * CLI can check a report's "**Row**: <id>" citations against real rows instead of
+ * trusting them.
+ *
+ * Why this exists: criteria-registry.md's own rule 1 is "Severity is read from this
+ * table, never chosen. ... Inventing a severity is a defect in the review." Nothing
+ * enforced that rule downstream: a report could cite a nonexistent row, or declare a
+ * Severity that disagrees with the row it names, and parse-report.js never checked.
+ * Same class of defect as the convention-baseline fabrication this module's sibling
+ * (convention-baseline.js) fixes, and the same fix: stop trusting the agent to get a
+ * checkable fact right, check it.
+ *
+ * The registry is the source of truth (per docs/explanation/test-review-cli-architecture.md's
+ * "Governing rule: the skill is the source of truth"), so this reads the real file
+ * shipped with the skill rather than a hardcoded copy that could drift from it —
+ * no sync test needed, because there is nothing to sync.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SEVERITY_ENUM = ['Critical', 'High', 'Medium', 'Low'];
+
+// Matches a criteria-registry.md row table line: | <ID> | <Criterion> | <Fires when> | <SEVERITY> | <Gate> |
+// The two `[^|]*\|` groups skip the Criterion and Fires-when cells, whatever their
+// content (both may be long free text, but never contain a literal pipe: an
+// unescaped `|` would itself break the source table's own rendering).
+const ROW_TABLE_LINE_PATTERN = /^\|\s*([CHML]\d+)\s*\|[^|]*\|[^|]*\|\s*(CRITICAL|HIGH|MEDIUM|LOW)\s*\|/gm;
+
+function titleCase(word) {
+  return word[0] + word.slice(1).toLowerCase();
+}
+
+/**
+ * Parse every row ID and its severity out of the skill's criteria-registry.md.
+ *
+ * @param {string} skillRoot - Resolved skill directory (contains steps-c/).
+ * @returns {object|null} `{ C1: 'Critical', H1: 'High', ... }`, or `null` when the
+ *   registry file is missing/unreadable/empty of rows (e.g. a bare-bones test
+ *   fixture skill root with no steps-c/ directory) — callers treat this as "no
+ *   grounding available" and skip the row/severity cross-check rather than fail
+ *   closed, since production skill installs always carry the real file.
+ */
+function loadRegistryRowSeverities(skillRoot) {
+  const registryPath = path.join(skillRoot, 'steps-c', 'criteria-registry.md');
+  let text;
+  try {
+    text = fs.readFileSync(registryPath, 'utf8');
+  } catch {
+    return null;
+  }
+  const severities = {};
+  for (const match of text.matchAll(ROW_TABLE_LINE_PATTERN)) {
+    severities[match[1]] = titleCase(match[2]);
+  }
+  return Object.keys(severities).length > 0 ? severities : null;
+}
+
+module.exports = { loadRegistryRowSeverities, SEVERITY_ENUM };

--- a/cli/test-review.js
+++ b/cli/test-review.js
@@ -47,6 +47,7 @@ const {
 const { buildPrompt } = require('./lib/build-prompt');
 const { parseReport, normalizeReportScore, verdictFor, scoreFails } = require('./lib/parse-report');
 const { computeConventionBaseline } = require('./lib/convention-baseline');
+const { loadRegistryRowSeverities } = require('./lib/registry-rows');
 const { runAgent } = require('./lib/run-agent');
 const { AGENT_ADAPTERS, resolveModel } = require('./lib/agent-adapters');
 const { withIsolation, selectBackend } = require('./lib/isolate');
@@ -561,6 +562,12 @@ function main() {
   // cross-check, so the two can never see a different corpus.
   const conventionBaseline = computeConventionBaseline({ projectRoot, reviewFiles: changedTestFiles });
 
+  // criteria-registry.md's row -> severity map, read from the skill itself so a
+  // report's "**Row**: <id>" citations can be checked against real rows instead of
+  // trusted. null on a skill root with no registry file (e.g. a bare test fixture);
+  // parseReport treats that as "no grounding available" rather than failing closed.
+  const registryRowSeverities = loadRegistryRowSeverities(skillRoot);
+
   if (options.agent === 'none') {
     const prompt = buildPrompt({
       skillRoot,
@@ -729,6 +736,7 @@ function main() {
         contextBasis,
         unscorableTestArtifacts,
         conventionBaseline,
+        registryRowSeverities,
       });
     } catch (error) {
       if (error.code === 'REPORT_UNPARSEABLE') {

--- a/cli/test-review.js
+++ b/cli/test-review.js
@@ -46,6 +46,7 @@ const {
 } = require('./lib/changed-tests');
 const { buildPrompt } = require('./lib/build-prompt');
 const { parseReport, normalizeReportScore, verdictFor, scoreFails } = require('./lib/parse-report');
+const { computeConventionBaseline } = require('./lib/convention-baseline');
 const { runAgent } = require('./lib/run-agent');
 const { AGENT_ADAPTERS, resolveModel } = require('./lib/agent-adapters');
 const { withIsolation, selectBackend } = require('./lib/isolate');
@@ -553,6 +554,13 @@ function main() {
     process.exit(skipFails && !waiver ? EXIT.VERDICT_FAIL : EXIT.PASS);
   }
 
+  // step-02-discover-tests.md §2b's convention baseline, computed here instead of
+  // left to the agent to sample: see cli/lib/convention-baseline.js's header
+  // comment for why an agent-derived sampled fraction cannot be trusted. Computed
+  // once and reused for both the printed prompt and (below) the parsed-report
+  // cross-check, so the two can never see a different corpus.
+  const conventionBaseline = computeConventionBaseline({ projectRoot, reviewFiles: changedTestFiles });
+
   if (options.agent === 'none') {
     const prompt = buildPrompt({
       skillRoot,
@@ -566,6 +574,7 @@ function main() {
       focus: options.focus,
       unscorableTestArtifacts,
       forcedUnscorableCandidates,
+      conventionBaseline,
     });
     console.log(prompt);
     if (jsonPath) {
@@ -673,6 +682,7 @@ function main() {
     focus: options.focus,
     unscorableTestArtifacts,
     forcedUnscorableCandidates,
+    conventionBaseline,
   });
 
   const executeAgent = ({ agentCwd, spawnPrefix }) => {
@@ -718,6 +728,7 @@ function main() {
         contextFiles,
         contextBasis,
         unscorableTestArtifacts,
+        conventionBaseline,
       });
     } catch (error) {
       if (error.code === 'REPORT_UNPARSEABLE') {

--- a/docs/explanation/test-review-cli-architecture.md
+++ b/docs/explanation/test-review-cli-architecture.md
@@ -13,7 +13,7 @@ A TEA workflow expects a human: it asks which mode to run and what inputs to use
 
 ---
 
-## Seven problems, seven modules
+## Eight problems, nine modules
 
 | Problem                                          | Module                               |
 | ------------------------------------------------ | ------------------------------------ |

--- a/docs/explanation/test-review-cli-architecture.md
+++ b/docs/explanation/test-review-cli-architecture.md
@@ -13,18 +13,21 @@ A TEA workflow expects a human: it asks which mode to run and what inputs to use
 
 ---
 
-## Five problems, five modules
+## Six problems, six modules
 
-| Problem                           | Module                               |
-| --------------------------------- | ------------------------------------ |
-| Find the skill                    | `lib/resolve-skill.js`               |
-| Decide what to feed it            | `lib/changed-tests.js`               |
-| Settle its configuration          | `lib/resolve-tea-config.js`          |
-| Make it run with no human present | `lib/build-prompt.js`                |
-| Spawn it without trusting it      | `lib/run-agent.js`, `lib/isolate.js` |
-| Turn prose into an exit code      | `lib/parse-report.js`                |
+| Problem                                          | Module                               |
+| ------------------------------------------------ | ------------------------------------ |
+| Find the skill                                   | `lib/resolve-skill.js`               |
+| Decide what to feed it                           | `lib/changed-tests.js`               |
+| Measure the house convention it's judged against | `lib/convention-baseline.js`         |
+| Settle its configuration                         | `lib/resolve-tea-config.js`          |
+| Make it run with no human present                | `lib/build-prompt.js`                |
+| Spawn it without trusting it                     | `lib/run-agent.js`, `lib/isolate.js` |
+| Turn prose into an exit code                     | `lib/parse-report.js`                |
 
-`cli/test-review.js` runs them in order: resolve skill, resolve config, split the diff, build prompt, spawn agent under isolation, parse report, emit verdict, exit.
+`cli/test-review.js` runs them in order: resolve skill, resolve config, split the diff, measure the convention baseline, build prompt, spawn agent under isolation, parse report, emit verdict, exit.
+
+`lib/convention-baseline.js` exists for the same reason the score is computed rather than trusted (see below): a live codex run on couture-cast PR #106 reported `Convention: priorityMarkers (18 of 40 sampled)` against a repo with zero real instances of that convention anywhere, because nothing forced the "sample the corpus" step the skill's own `step-02-discover-tests.md` §2b describes to be a real Glob/Grep instead of a plausible-sounding guess. The CLI now does that sampling itself — `git ls-files`, the review set excluded, ranked closest-first by directory distance, capped at 40 — states the result in the prompt as a fixed fact, and rejects (exit 3) a report whose `Convention: <key> (<adopted> of <sampled> sampled)` citations disagree with what it actually measured.
 
 ---
 

--- a/docs/explanation/test-review-cli-architecture.md
+++ b/docs/explanation/test-review-cli-architecture.md
@@ -13,19 +13,22 @@ A TEA workflow expects a human: it asks which mode to run and what inputs to use
 
 ---
 
-## Six problems, six modules
+## Seven problems, seven modules
 
 | Problem                                          | Module                               |
 | ------------------------------------------------ | ------------------------------------ |
 | Find the skill                                   | `lib/resolve-skill.js`               |
 | Decide what to feed it                           | `lib/changed-tests.js`               |
 | Measure the house convention it's judged against | `lib/convention-baseline.js`         |
+| Know what severity a finding is really allowed   | `lib/registry-rows.js`               |
 | Settle its configuration                         | `lib/resolve-tea-config.js`          |
 | Make it run with no human present                | `lib/build-prompt.js`                |
 | Spawn it without trusting it                     | `lib/run-agent.js`, `lib/isolate.js` |
 | Turn prose into an exit code                     | `lib/parse-report.js`                |
 
-`cli/test-review.js` runs them in order: resolve skill, resolve config, split the diff, measure the convention baseline, build prompt, spawn agent under isolation, parse report, emit verdict, exit.
+`cli/test-review.js` runs them in order: resolve skill, resolve config, split the diff, measure the convention baseline, load the registry's row severities, build prompt, spawn agent under isolation, parse report, emit verdict, exit.
+
+`lib/registry-rows.js` closes a second gap found while auditing the first: a report could document a real, row-cited Critical finding in prose while its `**Total Violations**:` summary line claimed zero, and nothing checked the two against each other — the CLI computed Approve at 100/100 straight from the summary line, the finding sitting right there unread. It reads `criteria-registry.md`'s row → severity map directly from the skill (never a hardcoded copy, so it can't drift), and `parse-report.js` uses it to bind every `**Row**: <id>` citation to a real row with a matching severity, and the number of Critical/High finding blocks actually documented to the counts the summary line claims. Scoped to Critical and High only — the two severities that actually flip `deriveRecommendation`'s output.
 
 `lib/convention-baseline.js` exists for the same reason the score is computed rather than trusted (see below): a live codex run on couture-cast PR #106 reported `Convention: priorityMarkers (18 of 40 sampled)` against a repo with zero real instances of that convention anywhere, because nothing forced the "sample the corpus" step the skill's own `step-02-discover-tests.md` §2b describes to be a real Glob/Grep instead of a plausible-sounding guess. The CLI now does that sampling itself — `git ls-files`, the review set excluded, ranked closest-first by directory distance, capped at 40 — states the result in the prompt as a fixed fact, and rejects (exit 3) a report whose `Convention: <key> (<adopted> of <sampled> sampled)` citations disagree with what it actually measured.
 

--- a/docs/reference/tea-test-review-cli.md
+++ b/docs/reference/tea-test-review-cli.md
@@ -188,11 +188,24 @@ A passing review (also written to `--json <file>` when given):
   "contextFiles": ["docs/stories/checkout-decline.md", "src/checkout/payment.ts"],
   "contextWaiversApplied": 0,
   "keyStrengths": ["Fully deterministic, no conditional branching or timing dependencies"],
-  "keyWeaknesses": ["Missing explicit test IDs on two test cases"]
+  "keyWeaknesses": ["Missing explicit test IDs on two test cases"],
+  "conventionBaseline": {
+    "baselineUnavailable": false,
+    "corpusSize": 47,
+    "sampled": 40,
+    "sampledFiles": ["tests/login.spec.ts", "tests/profile.spec.ts"],
+    "conventions": {
+      "priorityMarkers": { "mechanical": true, "adopted": 0, "mechanicalSignal": false },
+      "testIds": { "mechanical": true, "adopted": 6, "mechanicalSignal": true },
+      "bddNaming": { "mechanical": false }
+    }
+  }
 }
 ```
 
 `contextWaiversApplied` is strict and always `0`. `keyStrengths` and `keyWeaknesses` are best-effort, pulled from the report's Executive Summary bullet lists for PR-comment display; they're not part of the gating contract, a report that omits them still passes or fails on its own merits and the fields just come back as `[]`.
+
+`conventionBaseline` is the CLI's own deterministic measurement of step-02-discover-tests.md §2b's convention baseline — never the agent's — carried into the verdict alongside `agent`/`model` so a stored score also says what house convention it was judged against and how that was actually established. `sampledFiles` and per-key `mechanicalSignal` are computed by [`cli/lib/convention-baseline.js`](https://github.com/bmad-code-org/bmad-method-test-architecture-enterprise/blob/main/cli/lib/convention-baseline.js) by reading the real sampled files' content, not by asking the agent; the report's own `Convention: <key> (<adopted> of <sampled> sampled)` citations are rejected (exit 3) when they disagree with it — most pointedly, a citation claiming nonzero adoption for a key this scan found zero real occurrences of anywhere in the sampled corpus. The field is absent only when no baseline was computed for this run (e.g. a bare `parseReport` call in a unit test with no CLI around it).
 
 A failing verdict adds `gateFailures` (machine-readable reasons, e.g. `"insufficient evidence: 1 files reviewed (3 required)"`); a waived failure adds `waived`, `waiveReason`, `waiveUntil`.
 

--- a/docs/reference/tea-test-review-cli.md
+++ b/docs/reference/tea-test-review-cli.md
@@ -239,6 +239,7 @@ The report itself is strictly validated:
 - The Reviewed Files manifest
 - Exactly one `**Context Basis**` line in the Executive Summary, plus a run-bound `## Review Context` manifest whenever the basis is not `none`
 - Exactly one `**Context Waivers Applied**: 0` line in the Executive Summary
+- Every finding under `## Critical Issues (Must Fix)` / `## Recommendations (Should Fix)` cites a real `**Row**: <id>` whose criteria-registry.md severity matches its own `**Severity**` line; the number of Critical findings documented must equal the Critical count in `**Total Violations**`, and the number of P1 (High) findings documented must equal the High count
 
 Fenced code blocks are stripped first, so a quoted example can't spoof a verdict. Markdown emphasis is stripped only where it wraps a whole value, so `tests/user_profile.spec.ts` survives the manifest intact.
 
@@ -247,6 +248,8 @@ The score is computed rather than trusted: the CLI evaluates `100 - (Critical ×
 The bonus is read from the template's `Total Bonus:             +N` line, and a `| Total Bonus | N |` table row is accepted as well, because agents reflow the ledger into a table and a rendering choice should not decide a gate. Both forms normalize their `Final Score` and `Grade` fields, so the published ledger always agrees with the score the gate acted on. The prompt still pins the line form as the one to produce.
 
 A report declaring Critical violations alongside an approve-type recommendation is rejected as an inconsistent verdict (exit 3): Critical means Must Fix. Stale artifacts are never parsed, output files are deleted before the run and must be freshly written by it.
+
+The `**Total Violations**` summary line is not trusted either: the CLI counts the finding blocks actually documented under `## Critical Issues (Must Fix)` and the P1 (High) ones under `## Recommendations (Should Fix)`, and rejects a report whose summary disagrees with what it wrote (exit 3) — this closes a real defect where a report documented a genuine Critical finding in prose while its summary line claimed zero, and the CLI computed Approve at 100/100 from the summary alone. Scoped to Critical and High only, the two severities `deriveRecommendation` actually acts on ([`cli/lib/registry-rows.js`](https://github.com/bmad-code-org/bmad-method-test-architecture-enterprise/blob/main/cli/lib/registry-rows.js) reads the row→severity map straight from the skill's own `criteria-registry.md`, so this never drifts from the shipped rubric); Medium/Low counts are not cross-checked.
 
 ## Example workflow
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-02-discover-tests.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-02-discover-tests.md
@@ -80,6 +80,35 @@ before judging against it.
 Sample the repository's **existing** test corpus and measure what it actually
 does. Then `criteria-registry.md` scores each Convention row against the result.
 
+> **Exception — convention baseline supplied.** A headless run through
+> `tea-test-review` computes this baseline deterministically instead of leaving it
+> to you: `corpusSize`, `sampled`, the exact sampled file list, and — for
+> `priorityMarkers`, `testIds`, `networkFirst`, `dataFactories`, and `fixtures` — a
+> mechanical zero/nonzero adoption signal from actually reading every sampled
+> file's real content (see `cli/lib/convention-baseline.js`). When the prompt
+> states this data, use it verbatim: do not re-glob, re-sample, or re-derive
+> `corpusSize`/`sampled`, and read only the files named. The CLI independently
+> re-checks every `Convention: <key> (<adopted> of <sampled> sampled)` citation
+> against what it measured and rejects a report that disagrees — most pointedly,
+> a report that claims nonzero adoption for a key the CLI's own scan found zero
+> real occurrences of anywhere in the sampled corpus. `bddNaming` and
+> `assertionStyle` carry no mechanical signal (no single token distinguishes
+> "adopted" from "not" for a naming style or a dialect choice), so read the named
+> files yourself and judge those two; the sampled/corpusSize grounding still
+> applies to them.
+
+**No CLI, no exception: never estimate.** In every other context (an interactive
+run inside an editor, a `suite`-scope review with no headless wrapper), you must
+actually invoke a real search — Glob for the file list, Grep or a full read for
+the adoption count — before writing `corpusSize`, `sampled`, or an `adopted`
+count. A number that was not produced by reading real file contents is
+fabrication, not measurement, and is exactly the failure this section exists to
+prevent: a live run once reported `18 of 40 sampled` files carrying a
+`priorityMarkers` convention against a repository with zero real instances of a
+P0-P3 marker anywhere in it. Report the standard's absence honestly (see the
+`baselineUnavailable` fallback below) rather than produce a plausible-sounding
+number.
+
 ### Sampling rules
 
 - Sample test files that are **not in the review set**. A pull request adding four

--- a/src/workflows/testarch/bmad-testarch-test-review/test-review-template.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/test-review-template.md
@@ -78,16 +78,27 @@ Coverage mapping and coverage gates are out of scope here. Use `trace` for cover
 | Flakiness Patterns                   | {✅ PASS \| ✅ PASS (n/a) \| ⚠️ WARN \| ❌ FAIL} | {count}    | {basis}  | {brief_note} |
 
 <!-- {basis} states what decided the row, per steps-c/criteria-registry.md: `Absolute`,
-     `Applicability: <what the file must do>`, or `Convention: <key> (<adopted> of <sampled>)`.
-     A `✅ PASS (n/a)` row MUST name why the gate was closed and MUST deduct nothing — an absent
-     convention or an inapplicable pattern is not a finding. A bare WARN with no basis is the
-     defect this column exists to prevent: it reads identically in a repo that has the
-     convention and one that has never used it, so the reader cannot tell drift from the
-     rubric's own preference. Never leave {basis} unfilled. -->
+     `Applicability: <what the file must do>`, or `Convention: <key> (<adopted> of <sampled> sampled)` —
+     that exact literal form, "sampled" spelled out both after the count and at the close, e.g.
+     `Convention: priorityMarkers (0 of 40 sampled)`. When a headless run supplies a pre-computed
+     `convention_baseline` (see step-02-discover-tests.md §2b's CLI exception), `<sampled>` here MUST
+     equal the corpus's `sampled` value exactly, and `<adopted>` MUST be 0 for any mechanically-checked
+     key the run reports found zero real occurrences of — the CLI parses this line verbatim and rejects
+     a report that disagrees with what it actually measured. A `✅ PASS (n/a)` row MUST name why the
+     gate was closed and MUST deduct nothing — an absent convention or an inapplicable pattern is not a
+     finding. A bare WARN with no basis is the defect this column exists to prevent: it reads identically
+     in a repo that has the convention and one that has never used it, so the reader cannot tell drift
+     from the rubric's own preference. Never leave {basis} unfilled. -->
 
 **Total Violations**: {critical_count} Critical, {high_count} High, {medium_count} Medium, {low_count} Low
 
-**Convention Baseline**: {sampled} test files sampled outside the review set{, or `unavailable: <reason>`}
+<!-- Exactly one line below, exactly one of two literal forms — the CLI parses it and rejects any other
+     shape: `{sampled} test files sampled outside the review set`, or, only when the baseline could not
+     be measured, `unavailable: {reason}` in place of the whole value after the colon. Omit the line
+     entirely only when a headless run recorded baselineUnavailable AND you are citing no
+     "Convention: <key> (...)" fraction anywhere in the report; otherwise it is required. -->
+
+**Convention Baseline**: {sampled} test files sampled outside the review set
 
 ---
 

--- a/src/workflows/testarch/bmad-testarch-test-review/test-review-template.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/test-review-template.md
@@ -80,7 +80,7 @@ Coverage mapping and coverage gates are out of scope here. Use `trace` for cover
 <!-- {basis} states what decided the row, per steps-c/criteria-registry.md: `Absolute`,
      `Applicability: <what the file must do>`, or `Convention: <key> (<adopted> of <sampled> sampled)` —
      that exact literal form, "sampled" spelled out both after the count and at the close, e.g.
-     `Convention: priorityMarkers (0 of 40 sampled)`. When a headless run supplies a pre-computed
+     `Convention: priorityMarkers ({adopted} of {sampled} sampled)`. When a headless run supplies a pre-computed
      `convention_baseline` (see step-02-discover-tests.md §2b's CLI exception), `<sampled>` here MUST
      equal the corpus's `sampled` value exactly, and `<adopted>` MUST be 0 for any mechanically-checked
      key the run reports found zero real occurrences of — the CLI parses this line verbatim and rejects

--- a/test/fixtures/test-review-cli/reports/approve-with-high.md
+++ b/test/fixtures/test-review-cli/reports/approve-with-high.md
@@ -44,6 +44,14 @@ Final Score:             93/100
 Grade:                   A
 ```
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+
 ## Decision
 
 **Recommendation**: Approve

--- a/test/fixtures/test-review-cli/reports/block.md
+++ b/test/fixtures/test-review-cli/reports/block.md
@@ -43,6 +43,56 @@ Final Score:             41/100
 Grade:                   F
 ```
 
+## Critical Issues (Must Fix)
+
+### 1. Fixture stub Critical finding 1
+
+**Severity**: P0 (Critical)
+**Row**: C1
+
+### 2. Fixture stub Critical finding 2
+
+**Severity**: P0 (Critical)
+**Row**: C2
+
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+### 2. Fixture stub High finding 2
+
+**Severity**: P1 (High)
+**Row**: H2
+
+### 3. Fixture stub High finding 3
+
+**Severity**: P1 (High)
+**Row**: H3
+
+### 4. Fixture stub High finding 4
+
+**Severity**: P1 (High)
+**Row**: H4
+
+### 5. Fixture stub High finding 5
+
+**Severity**: P1 (High)
+**Row**: H5
+
+### 6. Fixture stub High finding 6
+
+**Severity**: P1 (High)
+**Row**: H6
+
+### 7. Fixture stub High finding 7
+
+**Severity**: P1 (High)
+**Row**: H7
+
+
 ## Decision
 
 **Recommendation**: Block

--- a/test/fixtures/test-review-cli/reports/bonus-not-multiple.md
+++ b/test/fixtures/test-review-cli/reports/bonus-not-multiple.md
@@ -49,6 +49,19 @@ Final Score:             92/100
 Grade:                   A
 ```
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+### 2. Fixture stub High finding 2
+
+**Severity**: P1 (High)
+**Row**: H2
+
+
 ## Decision
 
 **Recommendation**: Approve

--- a/test/fixtures/test-review-cli/reports/context-basis-without-manifest.md
+++ b/test/fixtures/test-review-cli/reports/context-basis-without-manifest.md
@@ -44,6 +44,14 @@ Final Score:             93/100
 Grade:                   A
 ```
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+
 ## Decision
 
 **Recommendation**: Approve

--- a/test/fixtures/test-review-cli/reports/context-none-with-manifest.md
+++ b/test/fixtures/test-review-cli/reports/context-none-with-manifest.md
@@ -44,6 +44,14 @@ Final Score:             93/100
 Grade:                   A
 ```
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+
 ## Decision
 
 **Recommendation**: Approve

--- a/test/fixtures/test-review-cli/reports/context-overlaps-reviewed.md
+++ b/test/fixtures/test-review-cli/reports/context-overlaps-reviewed.md
@@ -44,6 +44,14 @@ Final Score:             93/100
 Grade:                   A
 ```
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+
 ## Decision
 
 **Recommendation**: Approve

--- a/test/fixtures/test-review-cli/reports/context-pr-diff.md
+++ b/test/fixtures/test-review-cli/reports/context-pr-diff.md
@@ -64,6 +64,14 @@ The story raised AC-3 in this PR and `src/checkout/payment.ts` gained the
 decline branch that implements it. No test in the review set touches that path,
 so the gap is a finding rather than an inference.
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+
 ## Decision
 
 **Recommendation**: Approve with Comments

--- a/test/fixtures/test-review-cli/reports/convention-baseline-unavailable.md
+++ b/test/fixtures/test-review-cli/reports/convention-baseline-unavailable.md
@@ -33,9 +33,9 @@ instead of guessing a baseline from the reviewed files themselves.
 
 | Criterion                      | Status        | Violations | Basis                          | Notes                                  |
 | ------------------------------- | ------------- | ---------- | -------------------------------- | ---------------------------------------- |
-| Priority Markers (P0/P1/P2/P3) | ✅ PASS (n/a) | 0          | Convention: priorityMarkers n/a | baseline could not be measured (no test files exist outside the review set) |
+| Priority Markers (P0/P1/P2/P3) | ✅ PASS (n/a) | 0          | Convention: priorityMarkers n/a | baseline could not be measured (no test files exist outside the review set to measure a house convention against) |
 
-**Convention Baseline**: unavailable: no test files exist outside the review set
+**Convention Baseline**: unavailable: no test files exist outside the review set to measure a house convention against
 
 ## Quality Score Breakdown
 

--- a/test/fixtures/test-review-cli/reports/convention-baseline-unavailable.md
+++ b/test/fixtures/test-review-cli/reports/convention-baseline-unavailable.md
@@ -1,0 +1,61 @@
+---
+workflowType: 'testarch-test-review'
+stepsCompleted:
+  - step-01-load-context
+  - step-02-discover-tests
+  - step-03-review-tests
+---
+
+# Test Quality Review: checkout.spec.ts
+
+**Quality Score**: 100/100 (A)
+**Review Date**: 2026-07-29
+**Review Scope**: single
+
+## Executive Summary
+
+**Overall Assessment**: Excellent
+
+**Recommendation**: Approve
+
+**Context Basis**: none
+
+**Context Waivers Applied**: 0
+
+### Summary
+
+No corpus exists outside the review set, so every Convention row passes as n/a
+instead of guessing a baseline from the reviewed files themselves.
+
+**Total Violations**: 0 Critical, 0 High, 0 Medium, 0 Low
+
+## Quality Criteria Assessment
+
+| Criterion                      | Status        | Violations | Basis                          | Notes                                  |
+| ------------------------------- | ------------- | ---------- | -------------------------------- | ---------------------------------------- |
+| Priority Markers (P0/P1/P2/P3) | ✅ PASS (n/a) | 0          | Convention: priorityMarkers n/a | baseline could not be measured (no test files exist outside the review set) |
+
+**Convention Baseline**: unavailable: no test files exist outside the review set
+
+## Quality Score Breakdown
+
+```
+Starting Score:          100
+Critical Violations:     -0 × 10 = -0
+High Violations:         -0 × 5 = -0
+Medium Violations:       -0 × 2 = -0
+Low Violations:          -0 × 1 = -0
+
+Total Bonus:             +0
+
+Final Score:             100/100
+Grade:                   A
+```
+
+## Decision
+
+**Recommendation**: Approve
+
+## Reviewed Files
+
+tests/checkout.spec.ts

--- a/test/fixtures/test-review-cli/reports/convention-fabricated.md
+++ b/test/fixtures/test-review-cli/reports/convention-fabricated.md
@@ -1,0 +1,62 @@
+---
+workflowType: 'testarch-test-review'
+stepsCompleted:
+  - step-01-load-context
+  - step-02-discover-tests
+  - step-03-review-tests
+---
+
+# Test Quality Review: checkout.spec.ts
+
+**Quality Score**: 99/100 (A)
+**Review Date**: 2026-07-29
+**Review Scope**: single
+
+## Executive Summary
+
+**Overall Assessment**: Excellent
+
+**Recommendation**: Approve with Comments
+
+**Context Basis**: none
+
+**Context Waivers Applied**: 0
+
+### Summary
+
+Reproduces couture-cast PR #106's actual defect: a plausible-sounding, specific
+sampled fraction cited for a convention the sampled corpus does not actually exhibit
+anywhere.
+
+**Total Violations**: 0 Critical, 0 High, 0 Medium, 1 Low
+
+## Quality Criteria Assessment
+
+| Criterion                      | Status    | Violations | Basis                                     | Notes                       |
+| ------------------------------- | --------- | ---------- | ------------------------------------------ | ---------------------------- |
+| Priority Markers (P0/P1/P2/P3) | ⚠️ WARN   | 1          | Convention: priorityMarkers (18 of 40 sampled) | fabricated adoption fraction |
+
+**Convention Baseline**: 40 test files sampled outside the review set
+
+## Quality Score Breakdown
+
+```
+Starting Score:          100
+Critical Violations:     -0 × 10 = -0
+High Violations:         -0 × 5 = -0
+Medium Violations:       -0 × 2 = -0
+Low Violations:          -1 × 1 = -1
+
+Total Bonus:             +0
+
+Final Score:             99/100
+Grade:                   A
+```
+
+## Decision
+
+**Recommendation**: Approve with Comments
+
+## Reviewed Files
+
+tests/checkout.spec.ts

--- a/test/fixtures/test-review-cli/reports/convention-honest-absent.md
+++ b/test/fixtures/test-review-cli/reports/convention-honest-absent.md
@@ -1,0 +1,61 @@
+---
+workflowType: 'testarch-test-review'
+stepsCompleted:
+  - step-01-load-context
+  - step-02-discover-tests
+  - step-03-review-tests
+---
+
+# Test Quality Review: checkout.spec.ts
+
+**Quality Score**: 100/100 (A)
+**Review Date**: 2026-07-29
+**Review Scope**: single
+
+## Executive Summary
+
+**Overall Assessment**: Excellent
+
+**Recommendation**: Approve
+
+**Context Basis**: none
+
+**Context Waivers Applied**: 0
+
+### Summary
+
+Honestly reports the convention as absent, matching what the sampled corpus
+actually contains.
+
+**Total Violations**: 0 Critical, 0 High, 0 Medium, 0 Low
+
+## Quality Criteria Assessment
+
+| Criterion                      | Status         | Violations | Basis                                    | Notes                              |
+| ------------------------------- | -------------- | ---------- | ------------------------------------------ | ----------------------------------- |
+| Priority Markers (P0/P1/P2/P3) | ✅ PASS (n/a)  | 0          | Convention: priorityMarkers (0 of 40 sampled) | the repo uses no such convention (0 of 40 sampled) |
+
+**Convention Baseline**: 40 test files sampled outside the review set
+
+## Quality Score Breakdown
+
+```
+Starting Score:          100
+Critical Violations:     -0 × 10 = -0
+High Violations:         -0 × 5 = -0
+Medium Violations:       -0 × 2 = -0
+Low Violations:          -0 × 1 = -0
+
+Total Bonus:             +0
+
+Final Score:             100/100
+Grade:                   A
+```
+
+## Decision
+
+**Recommendation**: Approve
+
+## Reviewed Files
+
+tests/checkout.spec.ts

--- a/test/fixtures/test-review-cli/reports/duplicate-breakdown-heading.md
+++ b/test/fixtures/test-review-cli/reports/duplicate-breakdown-heading.md
@@ -63,6 +63,21 @@ Grade:                   D
 
 **Total Violations**: 1 Critical, 1 High, 2 Medium, 3 Low
 
+## Critical Issues (Must Fix)
+
+### 1. Fixture stub Critical finding 1
+
+**Severity**: P0 (Critical)
+**Row**: C1
+
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+
 ## Decision
 
 **Recommendation**: Request Changes

--- a/test/fixtures/test-review-cli/reports/empty-steps-flow.md
+++ b/test/fixtures/test-review-cli/reports/empty-steps-flow.md
@@ -39,6 +39,14 @@ Final Score:             88/100
 Grade:                   B
 ```
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+
 ## Decision
 
 **Recommendation**: Approve

--- a/test/fixtures/test-review-cli/reports/key-strengths-weaknesses.md
+++ b/test/fixtures/test-review-cli/reports/key-strengths-weaknesses.md
@@ -55,6 +55,14 @@ Final Score:             88/100
 Grade:                   B
 ```
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+
 ## Decision
 
 **Recommendation**: Approve with Comments

--- a/test/fixtures/test-review-cli/reports/missing-breakdown.md
+++ b/test/fixtures/test-review-cli/reports/missing-breakdown.md
@@ -29,6 +29,14 @@ report must not pass on the strength of a number nobody can check.
 
 **Total Violations**: 0 Critical, 1 High, 1 Medium, 1 Low
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+
 ## Decision
 
 **Recommendation**: Approve

--- a/test/fixtures/test-review-cli/reports/missing-context-basis.md
+++ b/test/fixtures/test-review-cli/reports/missing-context-basis.md
@@ -42,6 +42,14 @@ Final Score:             93/100
 Grade:                   A
 ```
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+
 ## Decision
 
 **Recommendation**: Approve

--- a/test/fixtures/test-review-cli/reports/request-changes-critical.md
+++ b/test/fixtures/test-review-cli/reports/request-changes-critical.md
@@ -44,6 +44,51 @@ Final Score:             55/100
 Grade:                   F
 ```
 
+## Critical Issues (Must Fix)
+
+### 1. Fixture stub Critical finding 1
+
+**Severity**: P0 (Critical)
+**Row**: C1
+
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+### 2. Fixture stub High finding 2
+
+**Severity**: P1 (High)
+**Row**: H2
+
+### 3. Fixture stub High finding 3
+
+**Severity**: P1 (High)
+**Row**: H3
+
+### 4. Fixture stub High finding 4
+
+**Severity**: P1 (High)
+**Row**: H4
+
+### 5. Fixture stub High finding 5
+
+**Severity**: P1 (High)
+**Row**: H5
+
+### 6. Fixture stub High finding 6
+
+**Severity**: P1 (High)
+**Row**: H6
+
+### 7. Fixture stub High finding 7
+
+**Severity**: P1 (High)
+**Row**: H7
+
+
 ## Decision
 
 **Recommendation**: Request Changes

--- a/test/fixtures/test-review-cli/reports/request-changes.md
+++ b/test/fixtures/test-review-cli/reports/request-changes.md
@@ -44,6 +44,44 @@ Final Score:             63/100
 Grade:                   D
 ```
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+### 2. Fixture stub High finding 2
+
+**Severity**: P1 (High)
+**Row**: H2
+
+### 3. Fixture stub High finding 3
+
+**Severity**: P1 (High)
+**Row**: H3
+
+### 4. Fixture stub High finding 4
+
+**Severity**: P1 (High)
+**Row**: H4
+
+### 5. Fixture stub High finding 5
+
+**Severity**: P1 (High)
+**Row**: H5
+
+### 6. Fixture stub High finding 6
+
+**Severity**: P1 (High)
+**Row**: H6
+
+### 7. Fixture stub High finding 7
+
+**Severity**: P1 (High)
+**Row**: H7
+
+
 ## Decision
 
 **Recommendation**: Request Changes

--- a/test/fixtures/test-review-cli/reports/table-breakdown.md
+++ b/test/fixtures/test-review-cli/reports/table-breakdown.md
@@ -43,6 +43,19 @@ both the headline and the table.
 | Final score | 85 |
 | Grade | B |
 
+## Recommendations (Should Fix)
+
+### 1. Fixture stub High finding 1
+
+**Severity**: P1 (High)
+**Row**: H1
+
+### 2. Fixture stub High finding 2
+
+**Severity**: P1 (High)
+**Row**: H2
+
+
 ## Decision
 
 Recommendation: Request Changes

--- a/test/fixtures/test-review-cli/stub-agent.js
+++ b/test/fixtures/test-review-cli/stub-agent.js
@@ -11,7 +11,8 @@
  *   STUB_MODE          approve (default) | approve-low | block | request-changes |
  *                      request-changes-critical | critical-approve | conflict |
  *                      score-mismatch | partial | nothing | fail |
- *                      forbidden-write | stale-copy
+ *                      forbidden-write | stale-copy | fabricated-convention |
+ *                      honest-absent-convention
  *   STUB_ASSERT_STDIN  when "1", fail if the prompt did not arrive on stdin or
  *                      if any of it leaked into argv
  *   STUB_ASSERT_MODEL  expected model value; fail unless argv carries a model
@@ -129,6 +130,37 @@ const reportedContextFiles = process.env.STUB_CONTEXT_OVERRIDE
 const contextBasisMatch = prompt.match(/\*\*Context Basis\*\*: (none|pr_diff_truncated|pr_diff)/);
 const contextBasis = contextBasisMatch ? contextBasisMatch[1] : 'none';
 
+// Every real CLI run now supplies a pre-computed convention baseline (see
+// cli/lib/convention-baseline.js), which parse-report.js requires the report to
+// state honestly whenever one was actually measured — even the git fixtures used
+// by tests that have nothing to do with conventions can turn up a real (if tiny)
+// corpus once a --test-glob run leaves an unrelated tracked test file outside the
+// review set. Static report fixtures predate this contract, so — same treatment
+// as Reviewed Files / Review Context above — derive the required line from the
+// prompt and inject it whenever a fixture doesn't already declare its own.
+function conventionBaselineLineFromPrompt() {
+  const measuredMatch = prompt.match(/- corpusSize: \d+, sampled: (\d+)/);
+  if (measuredMatch) {
+    return `**Convention Baseline**: ${measuredMatch[1]} test files sampled outside the review set`;
+  }
+  // Greedy: correctly closes on the LAST ")" on the line even when the reason
+  // text itself contains parentheses (e.g. "git ls-files failed (not a git repo,
+  // or a git error)").
+  const unavailableMatch = prompt.match(/- baselineUnavailable: true \((.*)\)/);
+  return unavailableMatch ? `**Convention Baseline**: unavailable: ${unavailableMatch[1]}` : null;
+}
+const conventionBaselineLine = conventionBaselineLineFromPrompt();
+
+function insertLineBeforeHeading(report, heading, line) {
+  const lines = report.split('\n');
+  const insertion = lines.findIndex((entry) => entry === `## ${heading}`);
+  if (insertion === -1) {
+    return report;
+  }
+  lines.splice(insertion, 0, line, '');
+  return lines.join('\n');
+}
+
 function replaceManifestSection(report, heading, files, { remove = false, addBefore } = {}) {
   const lines = report.split('\n');
   const start = lines.findIndex((line) => line === `## ${heading}`);
@@ -171,6 +203,9 @@ function bindReportToPrompt(report) {
       { addBefore: 'Quality Score Breakdown' },
     );
   }
+  if (conventionBaselineLine && !/^\*\*Convention Baseline\*\*:/m.test(bound)) {
+    bound = insertLineBeforeHeading(bound, 'Quality Score Breakdown', conventionBaselineLine);
+  }
   return bound;
 }
 
@@ -193,6 +228,79 @@ if (mode === 'forbidden-write') {
     // Expected under isolation: the write is denied, so the review can proceed.
   }
   writeFixtureReport('approve.md');
+  process.exit(0);
+}
+
+// Reproduces couture-cast PR #106's actual defect (a codex run reporting
+// "Convention: priorityMarkers (18 of 40 sampled)" against a corpus with zero real
+// P0-P3 markers) end-to-end against a real CLI-computed baseline, instead of
+// asserting the un-integrated pieces in isolation. `sampled` is read out of the
+// prompt's pre-computed conventionBaseline block rather than hardcoded, so the test
+// stays correct regardless of how many files the git fixture happens to carry.
+if (mode === 'fabricated-convention' || mode === 'honest-absent-convention') {
+  const sampledMatch = prompt.match(/- corpusSize: \d+, sampled: (\d+)/);
+  if (!sampledMatch) {
+    console.error(`stub-agent: STUB_MODE=${mode} requires the prompt to state a measured (not unavailable) convention baseline`);
+    process.exit(91);
+  }
+  const sampled = sampledMatch[1];
+  const fabricating = mode === 'fabricated-convention';
+  const report = [
+    '---',
+    "workflowType: 'testarch-test-review'",
+    'stepsCompleted:',
+    '  - step-01-load-context',
+    '  - step-02-discover-tests',
+    '---',
+    '',
+    `**Quality Score**: ${fabricating ? 99 : 100}/100 (A)`,
+    '',
+    '## Executive Summary',
+    '',
+    `**Recommendation**: ${fabricating ? 'Approve with Comments' : 'Approve'}`,
+    '**Context Basis**: none',
+    '**Context Waivers Applied**: 0',
+    '',
+    '### Summary',
+    fabricating
+      ? 'Simulates a review agent inventing a plausible-sounding adoption fraction for a convention the CLI actually measured as absent.'
+      : 'Honestly reports the convention as absent, matching what the CLI itself measured over the real sampled corpus.',
+    '',
+    `**Total Violations**: 0 Critical, 0 High, 0 Medium, ${fabricating ? 1 : 0} Low`,
+    '',
+    '## Quality Criteria Assessment',
+    '',
+    '| Criterion | Status | Violations | Basis | Notes |',
+    '| --- | --- | --- | --- | --- |',
+    fabricating
+      ? `| Priority Markers (P0/P1/P2/P3) | ⚠️ WARN | 1 | Convention: priorityMarkers (3 of ${sampled} sampled) | fabricated: no test in the sampled corpus actually carries a P0-P3 marker |`
+      : `| Priority Markers (P0/P1/P2/P3) | ✅ PASS (n/a) | 0 | Convention: priorityMarkers (0 of ${sampled} sampled) | the repo uses no such convention (0 of ${sampled} sampled) |`,
+    '',
+    `**Convention Baseline**: ${sampled} test files sampled outside the review set`,
+    '',
+    '## Quality Score Breakdown',
+    '```',
+    'Starting Score:          100',
+    'Critical Violations:     -0 × 10 = -0',
+    'High Violations:         -0 × 5 = -0',
+    'Medium Violations:       -0 × 2 = -0',
+    `Low Violations:          -${fabricating ? 1 : 0} × 1 = -${fabricating ? 1 : 0}`,
+    '',
+    'Total Bonus:             +0',
+    '',
+    `Final Score:             ${fabricating ? 99 : 100}/100`,
+    'Grade:                   A',
+    '```',
+    '',
+    '## Decision',
+    '',
+    `**Recommendation**: ${fabricating ? 'Approve with Comments' : 'Approve'}`,
+    '',
+    '## Reviewed Files',
+    '',
+  ].join('\n');
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, bindReportToPrompt(report));
   process.exit(0);
 }
 

--- a/test/fixtures/test-review-cli/stub-agent.js
+++ b/test/fixtures/test-review-cli/stub-agent.js
@@ -12,7 +12,8 @@
  *                      request-changes-critical | critical-approve | conflict |
  *                      score-mismatch | partial | nothing | fail |
  *                      forbidden-write | stale-copy | fabricated-convention |
- *                      honest-absent-convention
+ *                      honest-absent-convention | fabricated-critical-count |
+ *                      honest-critical-count
  *   STUB_ASSERT_STDIN  when "1", fail if the prompt did not arrive on stdin or
  *                      if any of it leaked into argv
  *   STUB_ASSERT_MODEL  expected model value; fail unless argv carries a model
@@ -295,6 +296,77 @@ if (mode === 'fabricated-convention' || mode === 'honest-absent-convention') {
     '## Decision',
     '',
     `**Recommendation**: ${fabricating ? 'Approve with Comments' : 'Approve'}`,
+    '',
+    '## Reviewed Files',
+    '',
+  ].join('\n');
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.writeFileSync(outputPath, bindReportToPrompt(report));
+  process.exit(0);
+}
+
+// Reproduces the second live defect this repo found while auditing the first
+// (couture-cast PR #106's fabricated convention baseline): a report can document a
+// real, row-cited Critical finding in prose while its "**Total Violations**:" line
+// claims 0 Critical, and nothing checked the two against each other — the CLI
+// computed Approve at 100/100 straight from the summary line, the documented finding
+// never read. registry-rows.js + parse-report.js's verifyFindingSeverityCounts fixes
+// this; this mode reproduces the exact shape end-to-end.
+if (mode === 'fabricated-critical-count' || mode === 'honest-critical-count') {
+  const fabricating = mode === 'fabricated-critical-count';
+  const declaredCritical = fabricating ? 0 : 1;
+  const report = [
+    '---',
+    "workflowType: 'testarch-test-review'",
+    'stepsCompleted:',
+    '  - step-01-load-context',
+    '  - step-02-discover-tests',
+    '---',
+    '',
+    `**Quality Score**: ${fabricating ? 100 : 90}/100 (${fabricating ? 'A' : 'A'})`,
+    '',
+    '## Executive Summary',
+    '',
+    `**Recommendation**: ${fabricating ? 'Approve' : 'Block'}`,
+    '**Context Basis**: none',
+    '**Context Waivers Applied**: 0',
+    '',
+    '### Summary',
+    fabricating
+      ? 'Simulates a review agent documenting a real Critical finding while its own summary line claims zero.'
+      : 'Honestly declares the one Critical finding it documents.',
+    '',
+    `**Total Violations**: ${declaredCritical} Critical, 0 High, 0 Medium, 0 Low`,
+    '',
+    '## Critical Issues (Must Fix)',
+    '',
+    '### 1. Disabled test hides a real regression',
+    '',
+    '**Severity**: P0 (Critical)',
+    '**Location**: `tests/checkout.spec.ts:1`',
+    '**Row**: C1',
+    '**Criterion**: Disabled test',
+    '',
+    '**Issue Description**:',
+    'The whole suite is behind test.skip with no reason. Nothing here has run in months.',
+    '',
+    '## Quality Score Breakdown',
+    '```',
+    'Starting Score:          100',
+    `Critical Violations:     -${declaredCritical} × 10 = -${declaredCritical * 10}`,
+    'High Violations:         -0 × 5 = -0',
+    'Medium Violations:       -0 × 2 = -0',
+    'Low Violations:          -0 × 1 = -0',
+    '',
+    'Total Bonus:             +0',
+    '',
+    `Final Score:             ${100 - declaredCritical * 10}/100`,
+    'Grade:                   A',
+    '```',
+    '',
+    '## Decision',
+    '',
+    `**Recommendation**: ${fabricating ? 'Approve' : 'Block'}`,
     '',
     '## Reviewed Files',
     '',

--- a/test/test-test-review-cli.js
+++ b/test/test-test-review-cli.js
@@ -1013,7 +1013,10 @@ async function runTests() {
       };
       const unavailableBaseline = {
         baselineUnavailable: true,
-        reason: 'no test files exist outside the review set',
+        // The exact string cli/lib/convention-baseline.js's empty-corpus branch
+        // produces, not an abridged stand-in, so this contract stays a faithful
+        // mock of what a real run would actually supply.
+        reason: 'no test files exist outside the review set to measure a house convention against',
         corpusSize: 0,
         sampled: 0,
         sampledFiles: [],
@@ -1751,7 +1754,9 @@ async function runTests() {
     // parse-report.js's verifyConventionBaseline — see that file's own comment on
     // keeping the two in sync.
     assert(
-      !prompt.includes('convention baseline'),
+      !prompt.includes('**Convention Baseline**') &&
+        !prompt.includes('Convention: <key>') &&
+        !prompt.includes('---BEGIN CONVENTION CORPUS---'),
       'omitting conventionBaseline entirely emits no baseline block at all (opt-in, never silently assumed)',
     );
 

--- a/test/test-test-review-cli.js
+++ b/test/test-test-review-cli.js
@@ -1753,11 +1753,18 @@ async function runTests() {
     // block immediately above it. Every literal line here is read verbatim by
     // parse-report.js's verifyConventionBaseline — see that file's own comment on
     // keeping the two in sync.
+    // Distinct from the report-contract bullet's own instruction text: that bullet
+    // legitimately contains the literal strings '**Convention Baseline**' and
+    // 'Convention: <key>' ("Omit the ... line and any ... citation"), so checking
+    // for their absence would false-fail on the correct behavior. Anchor instead on
+    // conventionBaselinePromptLines' unique opening phrase and its corpus delimiter,
+    // neither of which appears anywhere in the omit-instruction text, and positively
+    // confirm the omit instruction itself fired.
     assert(
-      !prompt.includes('**Convention Baseline**') &&
-        !prompt.includes('Convention: <key>') &&
-        !prompt.includes('---BEGIN CONVENTION CORPUS---'),
-      'omitting conventionBaseline entirely emits no baseline block at all (opt-in, never silently assumed)',
+      !prompt.includes('convention baseline has already been computed') &&
+        !prompt.includes('---BEGIN CONVENTION CORPUS---') &&
+        prompt.includes('Omit the "**Convention Baseline**:" line'),
+      'omitting conventionBaseline entirely emits no baseline block at all, and the report contract says to omit the line (opt-in, never silently assumed)',
     );
 
     const measuredConventionPrompt = buildPrompt({

--- a/test/test-test-review-cli.js
+++ b/test/test-test-review-cli.js
@@ -56,6 +56,15 @@ const {
   CONTEXT_BASIS_ENUM,
 } = require('../cli/lib/parse-report');
 const {
+  computeConventionBaseline,
+  directoryDistance,
+  directoryOf,
+  measureConventions,
+  CONVENTION_KEYS,
+  MECHANICAL_CONVENTION_KEYS,
+  JUDGMENT_ONLY_CONVENTION_KEYS,
+} = require('../cli/lib/convention-baseline');
+const {
   isTestFile,
   isContextNoise,
   getChangedTestFiles,
@@ -971,6 +980,135 @@ async function runTests() {
       );
     }
 
+    // parse-report: convention-baseline grounding (couture-cast PR #106's actual
+    // defect — a fabricated "Convention: priorityMarkers (18 of 40 sampled)" against
+    // a repo with zero real instances of that convention). See
+    // cli/lib/convention-baseline.js and verifyConventionBaseline for the fix.
+    {
+      const measuredBaseline = {
+        baselineUnavailable: false,
+        reason: null,
+        corpusSize: 40,
+        sampled: 40,
+        sampledFiles: [],
+        conventions: { priorityMarkers: { mechanical: true, adopted: 0, mechanicalSignal: false } },
+      };
+      const unavailableBaseline = {
+        baselineUnavailable: true,
+        reason: 'no test files exist outside the review set',
+        corpusSize: 0,
+        sampled: 0,
+        sampledFiles: [],
+        conventions: {},
+      };
+
+      try {
+        parseReport(readFixture('reports', 'convention-fabricated.md'), { conventionBaseline: measuredBaseline });
+        assert(false, 'a fabricated nonzero Convention citation against a zero-mechanical-signal corpus throws');
+      } catch (error) {
+        assert(
+          error.code === 'REPORT_UNPARSEABLE' && /found zero occurrences/.test(error.message) && /priorityMarkers/.test(error.message),
+          'a fabricated nonzero Convention citation against a zero-mechanical-signal corpus throws REPORT_UNPARSEABLE naming the key',
+          error.message,
+        );
+      }
+
+      const honest = parseReport(readFixture('reports', 'convention-honest-absent.md'), { conventionBaseline: measuredBaseline });
+      assert(
+        honest.conventionBaseline === measuredBaseline,
+        'a Convention citation matching the measured baseline exactly (0 of 40, zero signal) parses and the ground truth is surfaced on the parsed result',
+        JSON.stringify(honest.conventionBaseline),
+      );
+
+      const unavailableReport = parseReport(readFixture('reports', 'convention-baseline-unavailable.md'), {
+        conventionBaseline: unavailableBaseline,
+      });
+      assert(
+        unavailableReport.conventionBaseline === unavailableBaseline,
+        'a report correctly declaring "unavailable: <reason>" and citing no fraction parses when the run recorded baselineUnavailable',
+        JSON.stringify(unavailableReport.conventionBaseline),
+      );
+
+      try {
+        parseReport(readFixture('reports', 'convention-honest-absent.md'), {
+          conventionBaseline: unavailableBaseline,
+        });
+        assert(false, 'a Convention fraction cited while the run recorded baselineUnavailable throws');
+      } catch (error) {
+        assert(
+          error.code === 'REPORT_UNPARSEABLE' && /baselineUnavailable/.test(error.message),
+          'a Convention fraction cited while the run recorded baselineUnavailable throws REPORT_UNPARSEABLE (an unmeasurable baseline may never be cited as a specific fraction)',
+          error.message,
+        );
+      }
+
+      try {
+        parseReport(readFixture('reports', 'convention-honest-absent.md'), {
+          conventionBaseline: { ...measuredBaseline, sampled: 12, corpusSize: 12 },
+        });
+        assert(false, "a Convention citation whose sampled count disagrees with the run's real corpus throws");
+      } catch (error) {
+        assert(
+          error.code === 'REPORT_UNPARSEABLE' && /sampled 12 outside the review set/.test(error.message),
+          "a Convention citation whose sampled count disagrees with the run's real corpus throws REPORT_UNPARSEABLE, not a silent pass on a different corpus",
+          error.message,
+        );
+      }
+
+      try {
+        parseReport(readFixture('reports', 'approve.md'), { conventionBaseline: measuredBaseline });
+        assert(false, 'a report with no "**Convention Baseline**:" line throws when this run actually measured one');
+      } catch (error) {
+        assert(
+          error.code === 'REPORT_UNPARSEABLE' && /missing the "\*\*Convention Baseline\*\*:" line/.test(error.message),
+          'a report omitting the "**Convention Baseline**:" line throws REPORT_UNPARSEABLE when this run measured a real baseline (the line is optional only when the baseline is genuinely unavailable)',
+          error.message,
+        );
+      }
+
+      // Contract-free sanity checks: catch impossible citations even when no CLI
+      // ground truth was supplied at all (e.g. a bare unit test of an unrelated
+      // report shape), so the checks are never purely an opt-in feature.
+      try {
+        parseReport(
+          readFixture('reports', 'convention-fabricated.md').replace('priorityMarkers (18 of 40 sampled)', 'notARealKey (1 of 5 sampled)'),
+        );
+        assert(false, 'citing an unrecognized Convention key throws even with no runContract supplied');
+      } catch (error) {
+        assert(
+          error.code === 'REPORT_UNPARSEABLE' && /unrecognized Convention key "notARealKey"/.test(error.message),
+          'citing an unrecognized Convention key throws REPORT_UNPARSEABLE with no runContract needed',
+          error.message,
+        );
+      }
+      try {
+        parseReport(
+          readFixture('reports', 'convention-fabricated.md').replace(
+            'priorityMarkers (18 of 40 sampled)',
+            'priorityMarkers (41 of 40 sampled)',
+          ),
+        );
+        assert(false, 'a citation claiming more adopted than sampled throws even with no runContract supplied');
+      } catch (error) {
+        assert(
+          error.code === 'REPORT_UNPARSEABLE' && /41 adopted of only 40 sampled/.test(error.message),
+          'a citation claiming more adopted than sampled throws REPORT_UNPARSEABLE regardless of ground truth',
+          error.message,
+        );
+      }
+
+      // No runContract at all (the common case for every other fixture test in this
+      // suite): a report with no Convention Baseline line and no citations is
+      // untouched by this feature, proving it never turns into an unconditional
+      // requirement outside of a real CLI run.
+      const untouched = parseReport(readFixture('reports', 'approve.md'));
+      assert(
+        untouched.conventionBaseline === undefined,
+        'a report with no Convention citations and no runContract.conventionBaseline is unaffected by this check',
+        JSON.stringify(untouched),
+      );
+    }
+
     console.log('');
 
     // ============================================================
@@ -1588,6 +1726,112 @@ async function runTests() {
       'prompt requires the report to quote the focus note, so a score states what steered it',
     );
     assert(!prompt.includes('---BEGIN FOCUS---'), 'no focus note, no focus block: an unstated input stays unstated');
+
+    // build-prompt: convention baseline states pre-computed grounding as a fixed
+    // fact instead of an instruction to derive one, mirroring the review-set FILES
+    // block immediately above it. Every literal line here is read verbatim by
+    // parse-report.js's verifyConventionBaseline — see that file's own comment on
+    // keeping the two in sync.
+    assert(
+      !prompt.includes('convention baseline'),
+      'omitting conventionBaseline entirely emits no baseline block at all (opt-in, never silently assumed)',
+    );
+
+    const measuredConventionPrompt = buildPrompt({
+      skillRoot,
+      files: ['tests/checkout.spec.ts'],
+      outputPath: absoluteOutput,
+      conventionBaseline: {
+        baselineUnavailable: false,
+        reason: null,
+        corpusSize: 40,
+        sampled: 40,
+        sampledFiles: ['tests/login.spec.ts', 'tests/profile.spec.ts'],
+        conventions: {
+          priorityMarkers: { mechanical: true, adopted: 0, mechanicalSignal: false },
+          testIds: { mechanical: true, adopted: 6, mechanicalSignal: true },
+          bddNaming: { mechanical: false },
+          networkFirst: { mechanical: true, adopted: 0, mechanicalSignal: false },
+          dataFactories: { mechanical: true, adopted: 3, mechanicalSignal: true },
+          fixtures: { mechanical: true, adopted: 0, mechanicalSignal: false },
+          assertionStyle: { mechanical: false },
+        },
+      },
+    });
+    assert(
+      measuredConventionPrompt.includes('- corpusSize: 40, sampled: 40'),
+      'prompt states the CLI-measured corpusSize/sampled as a fixed fact',
+    );
+    assert(
+      measuredConventionPrompt.includes(
+        'The "**Convention Baseline**:" line must read exactly: 40 test files sampled outside the review set',
+      ),
+      'prompt states the exact required literal form for the Convention Baseline line, matching parse-report.js verbatim',
+    );
+    assert(
+      measuredConventionPrompt.includes('---BEGIN CONVENTION CORPUS---') &&
+        measuredConventionPrompt.includes(JSON.stringify(['tests/login.spec.ts', 'tests/profile.spec.ts'], null, 2)) &&
+        measuredConventionPrompt.includes('---END CONVENTION CORPUS---'),
+      'prompt names the exact sampled files as a delimited, do-not-substitute block',
+    );
+    assert(
+      /priorityMarkers: mechanically scanned across all 40 sampled files; zero occurrences[\s\S]*?MUST be reported as absent: adopted = 0/.test(
+        measuredConventionPrompt,
+      ),
+      'prompt forbids a nonzero priorityMarkers claim when the CLI already found zero occurrences in every sampled file',
+    );
+    assert(
+      /networkFirst: mechanically scanned across all 40 sampled files; zero occurrences/.test(measuredConventionPrompt),
+      'the zero-signal floor instruction applies uniformly to every mechanically-scanned key, not just priorityMarkers',
+    );
+    assert(
+      /testIds: mechanically scanned; at least one sampled file contains a recognized form\. Read the sampled files\s+yourself to judge the true adopted count \(0-40\)/.test(
+        measuredConventionPrompt,
+      ),
+      "a key with a nonzero mechanical signal is left to the agent's judgment for the true count, never forced to a specific number",
+    );
+    assert(
+      /bddNaming: not mechanically pre-scanned; read the sampled files yourself/.test(measuredConventionPrompt),
+      'a judgment-only key (no literal recognized form) is honestly disclosed as not mechanically pre-scanned',
+    );
+    assert(
+      /assertionStyle: not mechanically pre-scanned/.test(measuredConventionPrompt),
+      'the second judgment-only key is also disclosed the same way',
+    );
+
+    const unavailableConventionPrompt = buildPrompt({
+      skillRoot,
+      files: ['tests/checkout.spec.ts'],
+      outputPath: absoluteOutput,
+      conventionBaseline: {
+        baselineUnavailable: true,
+        reason: 'no test files exist outside the review set to measure a house convention against',
+        corpusSize: 0,
+        sampled: 0,
+        sampledFiles: [],
+        conventions: {},
+      },
+    });
+    assert(
+      unavailableConventionPrompt.includes(
+        'could NOT be\nmeasured: no test files exist outside the review set to measure a house convention against.',
+      ),
+      'prompt states the measured-unavailable reason verbatim',
+    );
+    assert(
+      unavailableConventionPrompt.includes(
+        'The "**Convention Baseline**:" line must read exactly:\nunavailable: no test files exist outside the review set to measure a house convention against',
+      ),
+      'prompt states the exact required unavailable literal form, matching parse-report.js verbatim',
+    );
+    assert(
+      unavailableConventionPrompt.includes('No finding, Basis column, or Note anywhere in the report may cite'),
+      'prompt forbids citing any sampled fraction at all when the baseline could not be measured',
+    );
+    assert(
+      !unavailableConventionPrompt.includes('---BEGIN CONVENTION CORPUS---'),
+      'no corpus block is emitted when there is no corpus to name',
+    );
 
     console.log('');
 
@@ -3332,6 +3576,83 @@ async function runTests() {
     );
     git(['checkout', 'main'], gitRepo);
 
+    // couture-cast PR #106 end-to-end reproduction: a codex run reported
+    // "Convention: priorityMarkers (18 of 40 sampled)" against a repo with zero real
+    // P0-P3 markers anywhere. These corpus files exist on `main`, before the review
+    // branch forks, so they sit outside the diff (the review set) while remaining
+    // real, `git ls-files`-discoverable neighbors of the reviewed file — exactly what
+    // cli/lib/convention-baseline.js samples. None of them carries a priority marker
+    // in any recognized form.
+    fs.writeFileSync(path.join(gitRepo, 'tests', 'login.spec.ts'), "test('logs in with valid credentials', () => {});\n");
+    fs.writeFileSync(path.join(gitRepo, 'tests', 'profile.spec.ts'), "test('updates the profile name', () => {});\n");
+    fs.writeFileSync(path.join(gitRepo, 'tests', 'orders.spec.ts'), "test('lists recent orders', () => {});\n");
+    fs.writeFileSync(path.join(gitRepo, 'tests', 'cart.spec.ts'), "test('adds an item to the cart', () => {});\n");
+    git(['add', '.'], gitRepo);
+    git(['commit', '-m', 'add convention-baseline corpus (no priority markers anywhere)'], gitRepo);
+
+    git(['checkout', '-b', 'convention-baseline-review'], gitRepo);
+    fs.writeFileSync(
+      path.join(gitRepo, 'tests', 'checkout.spec.ts'),
+      "test('checkout with the convention-baseline scenario', () => {});\n",
+    );
+    git(['add', '.'], gitRepo);
+    git(['commit', '-m', 'change only the reviewed file'], gitRepo);
+
+    const fabricatedConventionRun = runCli(
+      [
+        '--base',
+        'main',
+        '--project-root',
+        gitRepo,
+        '--output',
+        path.join(tmpRoot, 'git-fabricated-convention', 'test-review.md'),
+        '--agent-cmd',
+        stubAgent,
+        '--no-isolate',
+        ...stubPass('STUB_MODE'),
+      ],
+      { STUB_MODE: 'fabricated-convention' },
+    );
+    assert(
+      fabricatedConventionRun.status === 3 &&
+        fabricatedConventionRun.stderr.includes('found zero occurrences') &&
+        fabricatedConventionRun.stderr.includes('priorityMarkers'),
+      'git fixture: a report fabricating priorityMarkers adoption against a real zero-signal corpus is rejected end-to-end (exit 3), never published',
+      `status=${fabricatedConventionRun.status} stderr=${fabricatedConventionRun.stderr}`,
+    );
+
+    const honestAbsentConventionRun = runCli(
+      [
+        '--base',
+        'main',
+        '--project-root',
+        gitRepo,
+        '--output',
+        path.join(tmpRoot, 'git-honest-absent-convention', 'test-review.md'),
+        '--agent-cmd',
+        stubAgent,
+        '--no-isolate',
+        ...stubPass('STUB_MODE'),
+      ],
+      { STUB_MODE: 'honest-absent-convention' },
+    );
+    let honestVerdict = null;
+    try {
+      honestVerdict = JSON.parse(honestAbsentConventionRun.stdout);
+    } catch {
+      // assert below reports the raw stdout on failure
+    }
+    assert(
+      honestAbsentConventionRun.status === 0 &&
+        honestVerdict?.recommendation === 'Approve' &&
+        honestVerdict?.conventionBaseline?.baselineUnavailable === false &&
+        honestVerdict?.conventionBaseline?.sampled === 4 &&
+        honestVerdict?.conventionBaseline?.conventions?.priorityMarkers?.mechanicalSignal === false,
+      'git fixture: honestly reporting priorityMarkers as absent against the same real corpus passes end-to-end, and the verdict JSON carries the CLI-measured baseline (sampled=4, zero mechanical signal)',
+      `status=${honestAbsentConventionRun.status} stdout=${honestAbsentConventionRun.stdout} stderr=${honestAbsentConventionRun.stderr}`,
+    );
+    git(['checkout', 'main'], gitRepo);
+
     console.log('');
 
     // ============================================================
@@ -3779,6 +4100,127 @@ async function runTests() {
       badPactMcpRun.status === 2 && badPactMcpRun.stderr.includes('--pact-mcp must be one of'),
       'CLI end-to-end: an out-of-enum --pact-mcp is an environment error (exit 2)',
       `status=${badPactMcpRun.status} stderr=${badPactMcpRun.stderr}`,
+    );
+
+    console.log('');
+
+    // ============================================================
+    // Test Suite 11: convention-baseline
+    // ============================================================
+    console.log(`${colors.yellow}Test Suite 11: convention-baseline${colors.reset}\n`);
+
+    assert(
+      CONVENTION_KEYS.length === 7 &&
+        MECHANICAL_CONVENTION_KEYS.length === 5 &&
+        JUDGMENT_ONLY_CONVENTION_KEYS.length === 2 &&
+        MECHANICAL_CONVENTION_KEYS.every((key) => CONVENTION_KEYS.includes(key)) &&
+        JUDGMENT_ONLY_CONVENTION_KEYS.every((key) => CONVENTION_KEYS.includes(key)),
+      'the seven step-02 §2b convention keys split into five mechanically-detectable and two judgment-only, covering every key exactly once',
+      JSON.stringify({ CONVENTION_KEYS, MECHANICAL_CONVENTION_KEYS, JUDGMENT_ONLY_CONVENTION_KEYS }),
+    );
+
+    assert(directoryOf('tests/checkout.spec.ts') === 'tests', 'directoryOf strips the filename');
+    assert(directoryOf('checkout.spec.ts') === '', 'directoryOf returns "" for a root-level file');
+    assert(directoryDistance('tests/e2e', 'tests/e2e') === 0, 'directoryDistance is 0 for the same directory');
+    assert(directoryDistance('tests/e2e', 'tests/unit') === 2, 'directoryDistance counts one differing segment on each side as 2');
+    assert(directoryDistance('a/b/c', 'a') === 2, 'directoryDistance counts unshared depth past a common prefix');
+    assert(directoryDistance('', 'tests/e2e') === 2, 'directoryDistance handles a root-level directory on one side');
+
+    const cbRoot = path.join(tmpRoot, 'convention-baseline-fixture');
+    fs.mkdirSync(cbRoot, { recursive: true });
+
+    assert(
+      computeConventionBaseline({ projectRoot: cbRoot, reviewFiles: ['tests/checkout.spec.ts'] }).baselineUnavailable === true,
+      'a directory that is not a git repo at all reports baselineUnavailable (git ls-files fails) instead of throwing',
+    );
+
+    git(['init', '-b', 'main'], cbRoot);
+    git(['config', 'user.email', 'tea-tests@example.com'], cbRoot);
+    git(['config', 'user.name', 'TEA Tests'], cbRoot);
+    git(['config', 'commit.gpgsign', 'false'], cbRoot);
+    fs.mkdirSync(path.join(cbRoot, 'tests'), { recursive: true });
+    fs.writeFileSync(path.join(cbRoot, 'tests', 'checkout.spec.ts'), "test('checkout', () => {});\n");
+    git(['add', '.'], cbRoot);
+    git(['commit', '-m', 'only the reviewed file'], cbRoot);
+
+    const soleFileBaseline = computeConventionBaseline({ projectRoot: cbRoot, reviewFiles: ['tests/checkout.spec.ts'] });
+    assert(
+      soleFileBaseline.baselineUnavailable === true && /no test files exist outside the review set/.test(soleFileBaseline.reason),
+      'a repo whose only test file IS the reviewed file reports baselineUnavailable with the step-02 §2b reason, not a zero-sample false measurement',
+      JSON.stringify(soleFileBaseline),
+    );
+
+    // A close neighbor (same directory as the reviewed file) and a distant one
+    // (nested three levels under an unrelated directory), plus enough filler to
+    // exceed the 40-file cap and prove ranking, not just membership.
+    fs.writeFileSync(path.join(cbRoot, 'tests', 'login.spec.ts'), "test('[P1] logs in', () => { expect(true).toBe(true); });\n");
+    fs.mkdirSync(path.join(cbRoot, 'legacy', 'archive', 'old-suite'), { recursive: true });
+    fs.writeFileSync(
+      path.join(cbRoot, 'legacy', 'archive', 'old-suite', 'ancient.spec.ts'),
+      "test('ancient', () => { expect(true).toBe(true); });\n",
+    );
+    // Named to sort AFTER "login.spec.ts" alphabetically (tie-break order at equal
+    // distance), so the cap test below proves ranking by distance, not an artifact
+    // of alphabetical luck: login.spec.ts must survive the 40-file cap on its
+    // distance alone, with 45 same-distance rivals crowding in behind it.
+    for (let index = 0; index < 45; index++) {
+      fs.writeFileSync(path.join(cbRoot, 'tests', `zzz-filler-${String(index).padStart(2, '0')}.spec.ts`), "test('filler', () => {});\n");
+    }
+    git(['add', '.'], cbRoot);
+    git(['commit', '-m', 'add corpus: close neighbor, distant file, and cap-exceeding filler'], cbRoot);
+
+    const rankedBaseline = computeConventionBaseline({ projectRoot: cbRoot, reviewFiles: ['tests/checkout.spec.ts'] });
+    assert(
+      rankedBaseline.baselineUnavailable === false && rankedBaseline.corpusSize === 47,
+      'corpusSize counts every eligible file outside the review set, uncapped (1 login + 1 ancient + 45 filler)',
+      JSON.stringify({ corpusSize: rankedBaseline.corpusSize, baselineUnavailable: rankedBaseline.baselineUnavailable }),
+    );
+    assert(rankedBaseline.sampled === 40, 'sampled is capped at 40 even though 47 files are eligible', String(rankedBaseline.sampled));
+    assert(
+      !rankedBaseline.sampledFiles.includes('legacy/archive/old-suite/ancient.spec.ts'),
+      'closest-first ranking drops the distant file before the cap is reached (same-directory neighbors rank first)',
+      JSON.stringify(rankedBaseline.sampledFiles),
+    );
+    assert(
+      rankedBaseline.sampledFiles.includes('tests/login.spec.ts'),
+      'the same-directory neighbor survives the cap',
+      JSON.stringify(rankedBaseline.sampledFiles),
+    );
+    assert(
+      rankedBaseline.conventions.priorityMarkers.mechanical === true &&
+        rankedBaseline.conventions.priorityMarkers.adopted === 1 &&
+        rankedBaseline.conventions.priorityMarkers.mechanicalSignal === true,
+      'mechanical scan finds the one real "[P1]" marker among the sampled files and reports a nonzero signal',
+      JSON.stringify(rankedBaseline.conventions.priorityMarkers),
+    );
+    assert(
+      rankedBaseline.conventions.testIds.mechanical === true &&
+        rankedBaseline.conventions.testIds.adopted === 0 &&
+        rankedBaseline.conventions.testIds.mechanicalSignal === false,
+      "mechanical scan correctly finds zero testIds occurrences: this is the exact shape of couture-cast PR #106's actual corpus",
+      JSON.stringify(rankedBaseline.conventions.testIds),
+    );
+    assert(
+      rankedBaseline.conventions.bddNaming.mechanical === false && rankedBaseline.conventions.assertionStyle.mechanical === false,
+      'the two judgment-only keys carry no adopted count or mechanicalSignal at all — never a guessed one',
+      JSON.stringify({ bddNaming: rankedBaseline.conventions.bddNaming, assertionStyle: rankedBaseline.conventions.assertionStyle }),
+    );
+    assert(
+      CONVENTION_KEYS.every((key) => Object.prototype.hasOwnProperty.call(rankedBaseline.conventions, key)),
+      'every one of the seven keys is present in the returned conventions object, mechanical or not',
+      JSON.stringify(Object.keys(rankedBaseline.conventions)),
+    );
+
+    // measureConventions in isolation: an unreadable file contributes no signal
+    // rather than crashing the whole scan.
+    const unreadableSignal = measureConventions({
+      projectRoot: cbRoot,
+      sampledFiles: ['tests/does-not-exist.spec.ts', 'tests/login.spec.ts'],
+    });
+    assert(
+      unreadableSignal.priorityMarkers.adopted === 1,
+      'a missing/unreadable sampled file is skipped rather than thrown on, and the real file is still scanned',
+      JSON.stringify(unreadableSignal.priorityMarkers),
     );
 
     console.log('');

--- a/test/test-test-review-cli.js
+++ b/test/test-test-review-cli.js
@@ -54,6 +54,7 @@ const {
   verdictFor,
   scoreFails,
   CONTEXT_BASIS_ENUM,
+  verifyFindingSeverityCounts,
 } = require('../cli/lib/parse-report');
 const {
   computeConventionBaseline,
@@ -64,6 +65,7 @@ const {
   MECHANICAL_CONVENTION_KEYS,
   JUDGMENT_ONLY_CONVENTION_KEYS,
 } = require('../cli/lib/convention-baseline');
+const { loadRegistryRowSeverities, SEVERITY_ENUM } = require('../cli/lib/registry-rows');
 const {
   isTestFile,
   isContextNoise,
@@ -870,6 +872,22 @@ async function runTests() {
       .replace(
         '**Total Violations**: {critical_count} Critical, {high_count} High, {medium_count} Medium, {low_count} Low',
         '**Total Violations**: 0 Critical, 0 High, 8 Medium, 1 Low',
+      )
+      // The template's own "{For each critical/recommendation issue:}" example
+      // blocks are instructional placeholder prose for the agent, not real
+      // content, but read raw they still look like one real "### N. Title" finding
+      // with "**Severity**: P0 (Critical)"/"P1 (High)" each — exactly the shape
+      // verifyFindingSeverityCounts now counts. Collapse both to the template's own
+      // "no findings" placeholder text, matching the 0 Critical / 0 High declared
+      // above (Medium/Low aren't cross-checked, so the Recommendations section can
+      // stay empty even though 8 Medium + 1 Low are declared).
+      .replace(
+        /(## Critical Issues \(Must Fix\)\n\n)[\s\S]*?(\n\n---\n\n## Recommendations \(Should Fix\)\n\n)/,
+        '$1No critical issues detected. ✅$2',
+      )
+      .replace(
+        /(## Recommendations \(Should Fix\)\n\n)[\s\S]*?(\n\n---\n\n## Best Practices Found)/,
+        '$1No additional recommendations. Test quality is excellent. ✅$2',
       )
       .replaceAll('**Context Basis**: {none | pr_diff | pr_diff_truncated}', '**Context Basis**: pr_diff')
       .replaceAll('{relative_path_1}', 'tests/checkout.spec.ts')
@@ -3297,6 +3315,14 @@ async function runTests() {
       path.join(fixtureProject, '_bmad', 'tea', 'workflows', 'testarch', 'bmad-testarch-test-review', 'SKILL.md'),
       path.join(gitSkillDir, 'SKILL.md'),
     );
+    // The real criteria-registry.md, so registryRowSeverities is populated for these
+    // git-fixture runs and the row/severity cross-check (not just the count check) is
+    // exercised end-to-end too.
+    fs.mkdirSync(path.join(gitSkillDir, 'steps-c'), { recursive: true });
+    fs.copyFileSync(
+      path.join(repoRoot, 'src', 'workflows', 'testarch', 'bmad-testarch-test-review', 'steps-c', 'criteria-registry.md'),
+      path.join(gitSkillDir, 'steps-c', 'criteria-registry.md'),
+    );
     fs.mkdirSync(path.join(gitRepo, 'tests'));
     fs.writeFileSync(path.join(gitRepo, 'tests', 'checkout.spec.ts'), "test('checkout', () => {});\n");
     fs.mkdirSync(path.join(gitRepo, 'src'));
@@ -3650,6 +3676,60 @@ async function runTests() {
         honestVerdict?.conventionBaseline?.conventions?.priorityMarkers?.mechanicalSignal === false,
       'git fixture: honestly reporting priorityMarkers as absent against the same real corpus passes end-to-end, and the verdict JSON carries the CLI-measured baseline (sampled=4, zero mechanical signal)',
       `status=${honestAbsentConventionRun.status} stdout=${honestAbsentConventionRun.stdout} stderr=${honestAbsentConventionRun.stderr}`,
+    );
+
+    // Second live defect, same investigation: a report documenting a real Critical
+    // finding while its own summary line claims zero.
+    const fabricatedCriticalCountRun = runCli(
+      [
+        '--base',
+        'main',
+        '--project-root',
+        gitRepo,
+        '--output',
+        path.join(tmpRoot, 'git-fabricated-critical-count', 'test-review.md'),
+        '--agent-cmd',
+        stubAgent,
+        '--no-isolate',
+        ...stubPass('STUB_MODE'),
+      ],
+      { STUB_MODE: 'fabricated-critical-count' },
+    );
+    assert(
+      fabricatedCriticalCountRun.status === 3 &&
+        fabricatedCriticalCountRun.stderr.includes('declares 0 Critical') &&
+        fabricatedCriticalCountRun.stderr.includes('documents 1 finding'),
+      'git fixture: a report documenting a real Critical finding while its "Total Violations" line claims 0 is rejected end-to-end (exit 3), never published as a clean Approve',
+      `status=${fabricatedCriticalCountRun.status} stderr=${fabricatedCriticalCountRun.stderr}`,
+    );
+
+    const honestCriticalCountRun = runCli(
+      [
+        '--base',
+        'main',
+        '--project-root',
+        gitRepo,
+        '--output',
+        path.join(tmpRoot, 'git-honest-critical-count', 'test-review.md'),
+        '--agent-cmd',
+        stubAgent,
+        '--no-isolate',
+        ...stubPass('STUB_MODE'),
+      ],
+      { STUB_MODE: 'honest-critical-count' },
+    );
+    let honestCriticalVerdict = null;
+    try {
+      honestCriticalVerdict = JSON.parse(honestCriticalCountRun.stdout);
+    } catch {
+      // assert below reports the raw stdout on failure
+    }
+    assert(
+      honestCriticalCountRun.status === 1 &&
+        honestCriticalVerdict?.recommendation === 'Block' &&
+        honestCriticalVerdict?.violations?.critical === 1,
+      'git fixture: honestly declaring the one documented Critical finding passes parsing and fails the gate on its own merits (exit 1, Block) rather than the report itself being rejected',
+      `status=${honestCriticalCountRun.status} stdout=${honestCriticalCountRun.stdout} stderr=${honestCriticalCountRun.stderr}`,
     );
     git(['checkout', 'main'], gitRepo);
 
@@ -4221,6 +4301,238 @@ async function runTests() {
       unreadableSignal.priorityMarkers.adopted === 1,
       'a missing/unreadable sampled file is skipped rather than thrown on, and the real file is still scanned',
       JSON.stringify(unreadableSignal.priorityMarkers),
+    );
+
+    console.log('');
+
+    // ============================================================
+    // Test Suite 12: finding-severity-count grounding
+    // ============================================================
+    console.log(`${colors.yellow}Test Suite 12: finding-severity-count grounding${colors.reset}\n`);
+
+    // A live report once declared "0 Critical, 0 High..." in its summary line while
+    // documenting a real, row-cited Critical finding in prose beside it, and nothing
+    // downstream ever checked the two against each other: the CLI computed Approve
+    // at 100/100 straight from the summary, the finding sitting right there unread.
+    // registry-rows.js + verifyFindingSeverityCounts fix that; these tests prove it.
+    const registrySkillRoot = path.join(repoRoot, 'src', 'workflows', 'testarch', 'bmad-testarch-test-review');
+    const registryRowSeverities = loadRegistryRowSeverities(registrySkillRoot);
+    assert(
+      registryRowSeverities !== null && Object.keys(registryRowSeverities).length === 31,
+      'loadRegistryRowSeverities reads all 31 real rows (C1-C6, H1-H9, M1-M8, L1-L8) from criteria-registry.md',
+      JSON.stringify(registryRowSeverities ? Object.keys(registryRowSeverities).length : null),
+    );
+    assert(
+      registryRowSeverities.C1 === 'Critical' &&
+        registryRowSeverities.H5 === 'High' &&
+        registryRowSeverities.M2 === 'Medium' &&
+        registryRowSeverities.L7 === 'Low',
+      'a spot-check of known rows carries the registry-declared severity (C1 Critical, H5 High, M2 Medium, L7 Low)',
+      JSON.stringify({
+        C1: registryRowSeverities.C1,
+        H5: registryRowSeverities.H5,
+        M2: registryRowSeverities.M2,
+        L7: registryRowSeverities.L7,
+      }),
+    );
+    assert(
+      loadRegistryRowSeverities(path.join(fixturesRoot, 'project-empty')) === null,
+      'a skill root with no criteria-registry.md returns null (grounding unavailable) instead of throwing',
+    );
+    assert(
+      SEVERITY_ENUM.length === 4 && SEVERITY_ENUM.includes('Critical') && SEVERITY_ENUM.includes('Low'),
+      'SEVERITY_ENUM carries the four canonical severities',
+      JSON.stringify(SEVERITY_ENUM),
+    );
+
+    /** A minimal, valid report with N Critical / M High finding blocks citing the given rows. */
+    function findingReport({ totalCritical, totalHigh, criticalRows = [], highRows = [], recommendation = 'Approve' }) {
+      const findingBlock = (num, severityLabel, row) =>
+        `### ${num}. Fixture-only finding\n\n**Severity**: ${severityLabel}\n**Row**: ${row}\n`;
+      const lines = [
+        '---',
+        "workflowType: 'testarch-test-review'",
+        'stepsCompleted:',
+        '  - step-01-load-context',
+        '---',
+        '',
+        '**Quality Score**: 100/100 (A)',
+        '',
+        '## Executive Summary',
+        `**Recommendation**: ${recommendation}`,
+        '**Context Basis**: none',
+        '**Context Waivers Applied**: 0',
+        '',
+        `**Total Violations**: ${totalCritical} Critical, ${totalHigh} High, 0 Medium, 0 Low`,
+        '',
+      ];
+      if (criticalRows.length > 0) {
+        lines.push('## Critical Issues (Must Fix)', '');
+        for (const [i, row] of criticalRows.entries()) lines.push(findingBlock(i + 1, 'P0 (Critical)', row), '');
+      }
+      if (highRows.length > 0) {
+        lines.push('## Recommendations (Should Fix)', '');
+        for (const [i, row] of highRows.entries()) lines.push(findingBlock(i + 1, 'P1 (High)', row), '');
+      }
+      lines.push(
+        '## Quality Score Breakdown',
+        '```',
+        'Starting Score:          100',
+        `Critical Violations:     -${totalCritical} × 10 = -${totalCritical * 10}`,
+        `High Violations:         -${totalHigh} × 5 = -${totalHigh * 5}`,
+        'Medium Violations:       -0 × 2 = -0',
+        'Low Violations:          -0 × 1 = -0',
+        'Total Bonus:             +0',
+        `Final Score:             ${100 - totalCritical * 10 - totalHigh * 5}/100`,
+        'Grade:                   A',
+        '```',
+        '',
+        '## Decision',
+        `**Recommendation**: ${recommendation}`,
+        '',
+        '## Reviewed Files',
+        '- tests/x.spec.ts',
+      );
+      return lines.join('\n');
+    }
+
+    try {
+      parseReport(findingReport({ totalCritical: 0, totalHigh: 0, criticalRows: ['C1'] }), { registryRowSeverities });
+      assert(false, 'a real Critical finding documented while the summary claims 0 Critical throws');
+    } catch (error) {
+      assert(
+        error.code === 'REPORT_UNPARSEABLE' && /declares 0 Critical, but.*documents 1 finding/.test(error.message),
+        'a real Critical finding documented while the summary claims 0 Critical throws REPORT_UNPARSEABLE naming the mismatch (the exact defect this fix closes)',
+        error.message,
+      );
+    }
+
+    try {
+      parseReport(findingReport({ totalCritical: 2, totalHigh: 0, criticalRows: ['C1'], recommendation: 'Block' }), {
+        registryRowSeverities,
+      });
+      assert(false, 'over-declaring the Critical count relative to documented findings throws');
+    } catch (error) {
+      assert(
+        error.code === 'REPORT_UNPARSEABLE' && /declares 2 Critical, but.*documents 1 finding/.test(error.message),
+        'over-declaring Critical (2 claimed, 1 documented) throws too: the check is exact equality, not a floor',
+        error.message,
+      );
+    }
+
+    try {
+      const parsed = parseReport(
+        findingReport({ totalCritical: 1, totalHigh: 2, criticalRows: ['C1'], highRows: ['H1', 'H2'], recommendation: 'Block' }),
+        {
+          registryRowSeverities,
+        },
+      );
+      assert(
+        parsed.violations.critical === 1 && parsed.violations.high === 2,
+        'matching counts (1 Critical documented and declared, 2 High documented and declared) parse cleanly',
+        JSON.stringify(parsed.violations),
+      );
+    } catch (error) {
+      assert(false, 'matching Critical/High counts should parse, not throw', error.message);
+    }
+
+    try {
+      parseReport(findingReport({ totalCritical: 1, totalHigh: 0, criticalRows: ['H1'], recommendation: 'Block' }), {
+        registryRowSeverities,
+      });
+      assert(false, 'citing a real row whose registry severity disagrees with the declared Severity throws');
+    } catch (error) {
+      assert(
+        error.code === 'REPORT_UNPARSEABLE' && /Row "H1" \(registry severity High\) but declares Severity Critical/.test(error.message),
+        'citing H1 (registry severity High) under a P0 (Critical) finding throws: severity is read from the row, never chosen',
+        error.message,
+      );
+    }
+
+    try {
+      parseReport(findingReport({ totalCritical: 1, totalHigh: 0, criticalRows: ['C99'], recommendation: 'Block' }), {
+        registryRowSeverities,
+      });
+      assert(false, 'citing a nonexistent row throws');
+    } catch (error) {
+      assert(
+        error.code === 'REPORT_UNPARSEABLE' && /Row "C99", which is not a row in criteria-registry\.md/.test(error.message),
+        'citing a fabricated row ID (shaped correctly but not a real row) throws, naming it',
+        error.message,
+      );
+    }
+
+    try {
+      parseReport(
+        findingReport({ totalCritical: 1, totalHigh: 0, criticalRows: ['C1'], recommendation: 'Block' }).replace('**Row**: C1\n', ''),
+        {
+          registryRowSeverities,
+        },
+      );
+      assert(false, 'a finding with no Row line at all throws');
+    } catch (error) {
+      assert(
+        error.code === 'REPORT_UNPARSEABLE' && /has no "\*\*Row\*\*:" line/.test(error.message),
+        'a Critical Issues finding missing its Row line entirely throws, not silently accepted with no severity grounding',
+        error.message,
+      );
+    }
+
+    // Without registry data (e.g. a bare test-fixture skill root with no
+    // criteria-registry.md), the row must still be shaped like a real ID, but its
+    // existence/severity can't be cross-checked — a degraded, not a silent, mode.
+    try {
+      const parsed = parseReport(findingReport({ totalCritical: 1, totalHigh: 0, criticalRows: ['C1'], recommendation: 'Block' }));
+      assert(
+        parsed.violations.critical === 1,
+        'with no registryRowSeverities supplied, a shaped row ID still parses (count-matching alone is unconditional)',
+      );
+    } catch (error) {
+      assert(false, 'a real report should still parse with no registry data supplied', error.message);
+    }
+    try {
+      parseReport(findingReport({ totalCritical: 1, totalHigh: 0, criticalRows: ['banana'], recommendation: 'Block' }));
+      assert(false, 'an unshaped row token throws even with no registry data supplied');
+    } catch (error) {
+      assert(
+        error.code === 'REPORT_UNPARSEABLE' && /not a criteria-registry row ID/.test(error.message),
+        'a row token that is not even letter+digits shaped is rejected on shape alone, registry-independent',
+        error.message,
+      );
+    }
+
+    // Medium/Low are explicitly out of this fix's scope (they never flip the CI
+    // verdict away from "Approve with Comments"): a mismatched Medium count must NOT
+    // throw, proving the narrower guarantee is exactly as scoped, not accidentally
+    // stricter.
+    try {
+      const mediumMismatch = findingReport({ totalCritical: 0, totalHigh: 0, recommendation: 'Approve with Comments' }).replace(
+        '**Total Violations**: 0 Critical, 0 High, 0 Medium, 0 Low',
+        '**Total Violations**: 0 Critical, 0 High, 5 Medium, 0 Low',
+      );
+      const parsed = parseReport(mediumMismatch, { registryRowSeverities });
+      assert(
+        parsed.violations.medium === 5,
+        "a Medium count with zero documented Medium findings does NOT throw: Medium/Low are out of this fix's scope by design",
+        JSON.stringify(parsed.violations),
+      );
+    } catch (error) {
+      assert(false, 'Medium/Low counts must stay unchecked (out of scope)', error.message);
+    }
+
+    // build-prompt states the same contract it now enforces.
+    const findingCountsPrompt = buildPrompt({
+      skillRoot: registrySkillRoot,
+      files: ['tests/checkout.spec.ts'],
+      outputPath: path.join(tmpRoot, 'finding-counts-prompt', 'test-review.md'),
+    });
+    assert(
+      findingCountsPrompt.includes('registry severity must match') && findingCountsPrompt.includes('Critical-only by contract'),
+      "prompt states that a cited row's registry severity must match the finding's declared Severity",
+    );
+    assert(
+      findingCountsPrompt.includes('must equal the Critical count') && findingCountsPrompt.includes('must equal the High count'),
+      'prompt states that documented finding counts must equal the Total Violations counts exactly',
     );
 
     console.log('');


### PR DESCRIPTION
Two related fixes to `bmad-testarch-test-review`'s headless review pipeline, both closing the same class of defect: a claim the report makes that nothing downstream ever checked against reality.

## Fix 1: convention-baseline fabrication

couture-cast PR #106's codex-run review reported `Convention: priorityMarkers (18 of 40 sampled)` against a repo with zero real P0-P3 markers anywhere, verified with a repo-wide grep. `step-02-discover-tests.md`'s own design already forbade this ("guessing a convention is worse than admitting it wasn't measured"), but the sampling was entirely delegated to the agent's prompt-following: nothing forced a real Glob/Grep over real files, and nothing downstream checked the claim. Not one of the 33 existing report fixtures in this repo's own test suite even included a "Convention Baseline" line, and `parse-report.js` had no code path looking for one.

- `cli/lib/convention-baseline.js` (new): performs step-02 §2b's sampling for real (`git ls-files`, review set excluded, ranked closest-first by directory distance, capped at 40), and mechanically scans the sampled files' real content for five of the seven measured conventions. `bddNaming`/`assertionStyle` get no mechanical signal and stay agent-judged, with only sampled/corpusSize grounding.
- `build-prompt.js` states the computed baseline as a fixed fact; `parse-report.js`'s new `verifyConventionBaseline` rejects (exit 3) a report whose citations disagree with what was actually measured — most pointedly, a citation claiming nonzero adoption for a key the scan found zero real occurrences of.

## Fix 2: the violation summary was never checked against the findings either

Auditing fix 1 for the same class of defect turned up a second, more severe one: `parse-report.js` never read `## Critical Issues (Must Fix)` or `## Recommendations (Should Fix)` at all — only the agent's own `**Total Violations**:` summary line. Reproduced directly: a report can document a real, row-cited Critical finding in full prose, and if the summary line beside it says "0 Critical", the CLI computes **Approve at 100/100** — the documented finding is invisible to the gate.

- `cli/lib/registry-rows.js` (new): reads `criteria-registry.md`'s row → severity map straight from the skill (never a hardcoded copy).
- `parse-report.js`'s new `verifyFindingSeverityCounts` counts the finding blocks actually documented and binds them to the summary line exactly, and binds every `**Row**: <id>` citation to a real row with a matching severity ("severity is read from the row, never chosen" — the registry's own rule 1, previously unenforced downstream).
- Scoped to Critical and High only, deliberately: those are the two severities that actually flip `deriveRecommendation`'s output (Medium/Low only ever add "Approve with Comments" regardless of count).
- Fifteen pre-existing report fixtures needed minimal finding-block additions to keep declaring the same Critical/High counts they always have, now backed by real content; verified individually before touching any of them so their existing assertions stay intact.

## Test coverage

Both fixes ship with unit tests for the new modules, parse-report cross-checks (the exact exploit reproduction plus edge cases), build-prompt assertions, and end-to-end reproductions against a real temporary git repo (not just unit-level mocks) proving the fabricated case is rejected and the honest case passes.

## Not fixed here

Documented in `DESIGN-CRITERIA-REGISTRY.md`: of the seven keys step-02 measures, only three are actually Convention-gated in `criteria-registry.md`'s deduction schedule; that's an intentional prior design choice, not part of either bug.