### PR TITLE
chore: default persistent_facts to an empty array

### DIFF
--- a/src/agents/bmad-tea/customize.toml
+++ b/src/agents/bmad-tea/customize.toml
@@ -35,9 +35,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/standards.md"
 #     (glob patterns are supported; the file's contents are loaded and treated as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 role = "Master Test Architect responsible for risk-based testing, fixture architecture, ATDD, API testing, UI automation, and scalable quality gates across the BMad Method implementation phase."
 identity = "Test architect specializing in risk-based testing, fixture architecture, ATDD, API testing, backend services, UI automation, CI/CD governance, and scalable quality gates. Equally proficient in pure API/service-layer testing (pytest, JUnit, Go test, xUnit, RSpec) as in browser-based E2E testing (Playwright, Cypress), consumer-driven contract testing (Pact), and performance/load/chaos testing (k6). Supports GitHub Actions, GitLab CI, Jenkins, Azure DevOps, and Harness CI platforms."

--- a/src/workflows/testarch/bmad-teach-me-testing/customize.toml
+++ b/src/workflows/testarch/bmad-teach-me-testing/customize.toml
@@ -29,9 +29,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/test-standards.md"
 #     (glob patterns are supported; matching files load in lexical path order as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches its terminal step in any
 # mode (create, validate, edit), after the final outputs are produced.

--- a/src/workflows/testarch/bmad-testarch-atdd/customize.toml
+++ b/src/workflows/testarch/bmad-testarch-atdd/customize.toml
@@ -29,9 +29,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/test-standards.md"
 #     (glob patterns are supported; matching files load in lexical path order as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches its terminal step in any
 # mode (create, validate, edit), after the final outputs are produced.

--- a/src/workflows/testarch/bmad-testarch-automate/customize.toml
+++ b/src/workflows/testarch/bmad-testarch-automate/customize.toml
@@ -29,9 +29,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/test-standards.md"
 #     (glob patterns are supported; matching files load in lexical path order as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches its terminal step in any
 # mode (create, validate, edit), after the final outputs are produced.

--- a/src/workflows/testarch/bmad-testarch-ci/customize.toml
+++ b/src/workflows/testarch/bmad-testarch-ci/customize.toml
@@ -29,9 +29,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/test-standards.md"
 #     (glob patterns are supported; matching files load in lexical path order as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches its terminal step in any
 # mode (create, validate, edit), after the final outputs are produced.

--- a/src/workflows/testarch/bmad-testarch-framework/customize.toml
+++ b/src/workflows/testarch/bmad-testarch-framework/customize.toml
@@ -29,9 +29,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/test-standards.md"
 #     (glob patterns are supported; matching files load in lexical path order as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches its terminal step in any
 # mode (create, validate, edit), after the final outputs are produced.

--- a/src/workflows/testarch/bmad-testarch-nfr/customize.toml
+++ b/src/workflows/testarch/bmad-testarch-nfr/customize.toml
@@ -29,9 +29,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/test-standards.md"
 #     (glob patterns are supported; matching files load in lexical path order as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches its terminal step in any
 # mode (create, validate, edit), after the final outputs are produced.

--- a/src/workflows/testarch/bmad-testarch-test-design/customize.toml
+++ b/src/workflows/testarch/bmad-testarch-test-design/customize.toml
@@ -29,9 +29,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/test-standards.md"
 #     (glob patterns are supported; matching files load in lexical path order as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches its terminal step in any
 # mode (create, validate, edit), after the final outputs are produced.

--- a/src/workflows/testarch/bmad-testarch-test-review/customize.toml
+++ b/src/workflows/testarch/bmad-testarch-test-review/customize.toml
@@ -29,9 +29,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/test-standards.md"
 #     (glob patterns are supported; matching files load in lexical path order as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches its terminal step in any
 # mode (create, validate, edit), after the final outputs are produced.

--- a/src/workflows/testarch/bmad-testarch-trace/customize.toml
+++ b/src/workflows/testarch/bmad-testarch-trace/customize.toml
@@ -29,9 +29,7 @@ activation_steps_append = []
 #   - a file reference prefixed with `file:`, e.g. "file:{project-root}/docs/test-standards.md"
 #     (glob patterns are supported; matching files load in lexical path order as facts).
 
-persistent_facts = [
-  "file:{project-root}/**/project-context.md",
-]
+persistent_facts = []
 
 # Scalar: executed when the workflow reaches its terminal step in any
 # mode (create, validate, edit), after the final outputs are produced.


### PR DESCRIPTION
## What

Sets `persistent_facts = []` in every shipped `customize.toml`.

## Why

These files shipped pre-seeded with `"file:{project-root}/**/project-context.md"`, which made loading project-context an opt-out default baked into every skill rather than a customization the user chooses. `persistent_facts` is a user-customization surface; it should start empty.

## Notes

- Comments, spacing, and every other key are untouched — only the array value changes.
- Files that already had `persistent_facts = []` were left alone.
