### PR TITLE
test: assert persistent_facts ships empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `persistent_facts` ships empty. All ten `customize.toml` files — the TEA agent plus the nine `testarch` workflows — carried `persistent_facts = ["file:{project-root}/**/project-context.md"]` pre-seeded, which made loading that file an opt-out default baked into every skill rather than a customization you choose (#136).
+
+  Repository-wide context belongs in `AGENTS.md`, which every skill already sees. `persistent_facts` is for context that only one workflow needs, loaded when it runs instead of carried as constant memory. To opt a skill back in, add the entry to your team or user override TOML:
+
+  ```toml
+  persistent_facts = ["file:{project-root}/**/project-context.md"]
+  ```
+
+### Fixed
+
+- Installation component tests assert the current contract (#137). `test/test-installation-components.js` asserted that every `customize.toml` _contained_ the project-context glob. Emptying those arrays inverted ten assertions, taking `main` red and failing the follow-on Publish run. They now assert that `persistent_facts` ships as an empty array; the neighbouring checks that the key is present are unchanged.
+
 ## [1.23.0] - 2026-08-15
 
 ### Added

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -149,8 +149,8 @@ async function runTests() {
       assert(/^\s*icon\s*=\s*"🧪"/m.test(customizeContent), 'customize.toml pins agent.icon');
       assert(customizeContent.includes('persistent_facts'), 'customize.toml defines persistent_facts');
       assert(
-        customizeContent.includes('file:{project-root}/**/project-context.md'),
-        'customize.toml loads project-context.md as a persistent fact',
+        /^\s*persistent_facts\s*=\s*\[\s*\]/m.test(customizeContent),
+        'customize.toml ships persistent_facts empty (opt-in, not a baked default)',
       );
       assert(customizeContent.includes('activation_steps_prepend'), 'customize.toml defines activation_steps_prepend');
       assert(customizeContent.includes('activation_steps_append'), 'customize.toml defines activation_steps_append');
@@ -302,8 +302,8 @@ async function runTests() {
         assert(customizeContent.includes('persistent_facts'), `${dirName}/customize.toml defines persistent_facts`);
         assert(customizeContent.includes('on_complete'), `${dirName}/customize.toml defines on_complete`);
         assert(
-          customizeContent.includes('file:{project-root}/**/project-context.md'),
-          `${dirName}/customize.toml loads project-context.md as a persistent fact`,
+          /^\s*persistent_facts\s*=\s*\[\s*\]/m.test(customizeContent),
+          `${dirName}/customize.toml ships persistent_facts empty (opt-in, not a baked default)`,
         );
       } catch (error) {
         assert(false, `${dirName}/customize.toml validates`, error.message);


### PR DESCRIPTION
Fixes main, which is red after #136.

`test/test-installation-components.js` asserted that every `customize.toml` contained `file:{project-root}/**/project-context.md`. #136 emptied those arrays, so 10 assertions inverted. The merge took main red and the follow-on Publish run failed with the same 10 failures.

Assertions now check the current contract — `persistent_facts` ships as an empty array, opt-in rather than a baked default. The neighbouring `includes("persistent_facts")` assertions are untouched, so the key is still required to be present.

Local run: 781 passed, 0 failed.