### PR TITLE
fix: preserve validate-mode report history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Validate mode now writes a scope-specific, timestamped report for each run instead of reusing one fixed filename. Artifact validation reports record the exact files checked, and every validate workflow refuses to overwrite an existing report, so sequential and parallel QA runs retain independent history (#140).
+
 ## [1.23.3] - 2026-08-19
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Validate mode now writes a scope-specific, timestamped report for each run instead of reusing one fixed filename. Artifact validation reports record the exact files checked, and every validate workflow refuses to overwrite an existing report, so sequential and parallel QA runs retain independent history (#140).
+- Validate mode now writes a scope-specific, timestamped report for each run instead of reusing one fixed filename. Artifact validation reports record the exact files checked, and every validate workflow atomically reserves its report through exclusive creation with collision retry, so sequential and parallel QA runs retain independent history (#140).
 
 ## [1.23.3] - 2026-08-19
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -474,6 +474,14 @@ Paths are relative to `{test_artifacts}` unless noted. Deliverables are declared
 
 `trace` also reads an optional input it never writes: `live-verification-results.json`. Any producer may write it (an agent, a shell script, a CI job, or a person recording an outcome by hand). See [Live Verification Results](/docs/reference/live-verification-results.md) for the contract.
 
+### Validation Report History
+
+Validate mode preserves every report as a separate artifact. The eight artifact-producing workflows write `{workflow}-validation-report-{validation_scope}-{run_timestamp}.md` under `{test_artifacts}`. The workflow identifier is `atdd`, `automate`, `ci`, `framework`, `nfr-assess`, `test-design`, `test-review`, or `trace`.
+
+`validation_scope` identifies what was checked, such as `story-1-2`, `epic-9`, `system`, or `pull-request-123`. `run_timestamp` is the UTC start time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Each report also records the exact project-relative paths of its validated artifacts. Validate mode checks the resolved path before writing and refuses to overwrite an existing report.
+
+The `teach-me-testing` workflow validates its own workflow definition rather than a selected output scope. Its reports use `workflow-validation/teach-me-testing-validation-{run_timestamp}.md` under `{test_artifacts}` and follow the same no-overwrite rule.
+
 ---
 
 ## Environment Variables

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -478,7 +478,7 @@ Paths are relative to `{test_artifacts}` unless noted. Deliverables are declared
 
 Validate mode preserves every report as a separate artifact. The eight artifact-producing workflows write `{workflow}-validation-report-{validation_scope}-{run_timestamp}.md` under `{test_artifacts}`. The workflow identifier is `atdd`, `automate`, `ci`, `framework`, `nfr-assess`, `test-design`, `test-review`, or `trace`.
 
-`validation_scope` identifies what was checked, such as `story-1-2`, `epic-9`, `system`, or `pull-request-123`. `run_timestamp` is the UTC start time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Each report also records the exact project-relative paths of its validated artifacts. Validate mode checks the resolved path before writing and refuses to overwrite an existing report.
+`validation_scope` identifies what was checked, such as `story-1-2`, `epic-9`, `system`, or `pull-request-123`. `run_timestamp` is the UTC start time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Each report also records the exact project-relative paths of its validated artifacts. Validate mode atomically reserves the resolved path with exclusive creation. A collision produces a fresh timestamp and retry, so two concurrent runs cannot claim the same report.
 
 The `teach-me-testing` workflow validates its own workflow definition rather than a selected output scope. Its reports use `workflow-validation/teach-me-testing-validation-{run_timestamp}.md` under `{test_artifacts}` and follow the same no-overwrite rule.
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
@@ -4,7 +4,7 @@ description: 'Validate teach-me-testing workflow quality against BMAD standards'
 
 workflowPath: '{skill-root}'
 checklistFile: '{skill-root}/checklist.md'
-validationReport: '{test_artifacts}/workflow-validation/teach-me-testing-validation-{date}.md'
+validationReport: '{test_artifacts}/workflow-validation/teach-me-testing-validation-{run_timestamp}.md'
 ---
 
 # Validate Step 1: Quality Validation
@@ -30,6 +30,7 @@ To systematically validate the teach-me-testing workflow against BMAD quality st
 
 - 🎯 Focus on comprehensive validation
 - 🚫 FORBIDDEN to skip any checks
+- 🚫 Never overwrite an existing validation report
 - 💬 Report findings clearly
 
 ## EXECUTION PROTOCOLS:
@@ -40,7 +41,11 @@ To systematically validate the teach-me-testing workflow against BMAD quality st
 
 ## MANDATORY SEQUENCE
 
-### 1. Validation Start
+### 1. Resolve Unique Report Path
+
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{validationReport}`. Check whether that exact path exists before validation begins. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+
+### 2. Validation Start
 
 "**Validating Workflow: teach-me-testing**
 
@@ -59,7 +64,7 @@ This will validate:
 
 **Starting validation...**"
 
-### 2. Foundation Structure Validation
+### 3. Foundation Structure Validation
 
 **Check:**
 
@@ -72,7 +77,7 @@ This will validate:
 
 Report findings: Pass/Fail for each check.
 
-### 3. Template Validation
+### 4. Template Validation
 
 **Check templates/:**
 
@@ -85,7 +90,7 @@ Report findings: Pass/Fail for each check.
 
 Report findings.
 
-### 4. Step File Validation (CREATE Mode)
+### 5. Step File Validation (CREATE Mode)
 
 **For each of 12 steps in steps-c/:**
 
@@ -100,7 +105,7 @@ Report findings.
 
 Report findings per step.
 
-### 5. Data File Validation
+### 6. Data File Validation
 
 **Check data/:**
 
@@ -112,7 +117,7 @@ Report findings per step.
 
 Report findings.
 
-### 6. Content Quality Validation
+### 7. Content Quality Validation
 
 **Check session steps:**
 
@@ -125,7 +130,7 @@ Report findings.
 
 Report findings.
 
-### 7. State Management Validation
+### 8. State Management Validation
 
 **Check continuable workflow features:**
 
@@ -138,7 +143,7 @@ Report findings.
 
 Report findings.
 
-### 8. User Experience Validation
+### 9. User Experience Validation
 
 **Check UX:**
 
@@ -151,7 +156,7 @@ Report findings.
 
 Report findings.
 
-### 9. Generate Validation Report
+### 10. Generate Validation Report
 
 Create {validationReport}:
 
@@ -159,6 +164,7 @@ Create {validationReport}:
 ---
 workflow: teach-me-testing
 validation_date: { current_date }
+run_timestamp: { run_timestamp }
 validator: TEA Validation Workflow
 overall_status: PASS / FAIL / PASS_WITH_WARNINGS
 ---
@@ -231,7 +237,7 @@ overall_status: PASS / FAIL / PASS_WITH_WARNINGS
 **Status:** {READY_FOR_PRODUCTION / NEEDS_FIXES / PASS_WITH_MINOR_ISSUES}
 ```
 
-### 10. Display Results
+### 11. Display Results
 
 "**Validation Complete!**
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
@@ -43,7 +43,7 @@ To systematically validate the teach-me-testing workflow against BMAD quality st
 
 ### 1. Resolve Unique Report Path
 
-Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{validationReport}`. Check whether that exact path exists before validation begins. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{validationReport}`. Atomically reserve that path using an exclusive-create operation that fails if the file already exists. A separate existence check followed by a normal write is forbidden. On collision, generate a fresh timestamp, resolve a new path, and retry exclusive creation until it succeeds. Initialize the reserved file with `workflow: teach-me-testing`, `run_timestamp`, and `status: IN_PROGRESS`. This run may update only the file it reserved. If the workflow stops, leave that reservation in place. Never delete, truncate, or reuse a report from another run. Always refuse to overwrite prior validation history.
 
 ### 2. Validation Start
 
@@ -158,7 +158,7 @@ Report findings.
 
 ### 10. Generate Validation Report
 
-Create {validationReport}:
+Replace the `IN_PROGRESS` body in this run's reserved {validationReport} with:
 
 ```markdown
 ---

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{test_artifacts}/atdd-validation-report.md'
+outputFile: '{test_artifacts}/atdd-validation-report-{validation_scope}-{run_timestamp}.md'
 validationChecklist: '{skill-root}/checklist.md'
 ---
 
@@ -26,6 +26,7 @@ Validate outputs using the workflow checklist and record findings.
 
 - 🎯 Validate against `{validationChecklist}`
 - 🚫 Do not skip checks
+- 🚫 Never overwrite an existing validation report
 
 ## EXECUTION PROTOCOLS:
 
@@ -34,7 +35,7 @@ Validate outputs using the workflow checklist and record findings.
 
 ## CONTEXT BOUNDARIES:
 
-- Available context: workflow outputs and checklist
+- Available context: user-selected workflow outputs and checklist
 - Focus: validation only
 - Limits: do not modify outputs in this step
 
@@ -42,17 +43,25 @@ Validate outputs using the workflow checklist and record findings.
 
 **CRITICAL:** Follow this sequence exactly.
 
-### 1. Load Checklist
+### 1. Select Scope and Resolve Report Path
+
+Use the artifact paths the user supplied with the Validate request. If none were supplied, list the likely outputs for this workflow and ask which exact file or files to validate. When several candidates exist, do not guess.
+
+Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
+
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+
+### 2. Load Checklist
 
 Read `{validationChecklist}` and list all criteria.
 
-### 2. Validate Outputs
+### 3. Validate Outputs
 
 Evaluate outputs against each checklist item.
 
-### 3. Write Report
+### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
+Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 
@@ -60,6 +69,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 - Validation report written
 - All checklist items evaluated
+- All selected artifacts recorded in the report
 
 ### ❌ SYSTEM FAILURE:
 

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-v/step-01-validate.md
@@ -49,7 +49,7 @@ Use the artifact paths the user supplied with the Validate request. If none were
 
 Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
 
-Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{outputFile}` with both values. Atomically reserve that path using an exclusive-create operation that fails if the file already exists. A separate existence check followed by a normal write is forbidden. On collision, generate a fresh timestamp, resolve a new path, and retry exclusive creation until it succeeds. Initialize the reserved file with `validation_scope`, `run_timestamp`, `validated_artifacts`, and `status: IN_PROGRESS`. This run may update only the file it reserved. If the workflow stops, leave that reservation in place. Never delete, truncate, or reuse a report from another run. Always refuse to overwrite prior validation history.
 
 ### 2. Load Checklist
 
@@ -61,7 +61,7 @@ Evaluate outputs against each checklist item.
 
 ### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
+Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the final validation report. Include PASS/WARN/FAIL per section plus the original `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 

--- a/src/workflows/testarch/bmad-testarch-automate/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{test_artifacts}/automate-validation-report.md'
+outputFile: '{test_artifacts}/automate-validation-report-{validation_scope}-{run_timestamp}.md'
 validationChecklist: '{skill-root}/checklist.md'
 ---
 
@@ -26,6 +26,7 @@ Validate outputs using the workflow checklist and record findings.
 
 - 🎯 Validate against `{validationChecklist}`
 - 🚫 Do not skip checks
+- 🚫 Never overwrite an existing validation report
 
 ## EXECUTION PROTOCOLS:
 
@@ -34,7 +35,7 @@ Validate outputs using the workflow checklist and record findings.
 
 ## CONTEXT BOUNDARIES:
 
-- Available context: workflow outputs and checklist
+- Available context: user-selected workflow outputs and checklist
 - Focus: validation only
 - Limits: do not modify outputs in this step
 
@@ -42,17 +43,25 @@ Validate outputs using the workflow checklist and record findings.
 
 **CRITICAL:** Follow this sequence exactly.
 
-### 1. Load Checklist
+### 1. Select Scope and Resolve Report Path
+
+Use the artifact paths the user supplied with the Validate request. If none were supplied, list the likely outputs for this workflow and ask which exact file or files to validate. When several candidates exist, do not guess.
+
+Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
+
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+
+### 2. Load Checklist
 
 Read `{validationChecklist}` and list all criteria.
 
-### 2. Validate Outputs
+### 3. Validate Outputs
 
 Evaluate outputs against each checklist item.
 
-### 3. Write Report
+### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
+Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 
@@ -60,6 +69,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 - Validation report written
 - All checklist items evaluated
+- All selected artifacts recorded in the report
 
 ### ❌ SYSTEM FAILURE:
 

--- a/src/workflows/testarch/bmad-testarch-automate/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-v/step-01-validate.md
@@ -49,7 +49,7 @@ Use the artifact paths the user supplied with the Validate request. If none were
 
 Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
 
-Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{outputFile}` with both values. Atomically reserve that path using an exclusive-create operation that fails if the file already exists. A separate existence check followed by a normal write is forbidden. On collision, generate a fresh timestamp, resolve a new path, and retry exclusive creation until it succeeds. Initialize the reserved file with `validation_scope`, `run_timestamp`, `validated_artifacts`, and `status: IN_PROGRESS`. This run may update only the file it reserved. If the workflow stops, leave that reservation in place. Never delete, truncate, or reuse a report from another run. Always refuse to overwrite prior validation history.
 
 ### 2. Load Checklist
 
@@ -61,7 +61,7 @@ Evaluate outputs against each checklist item.
 
 ### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
+Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the final validation report. Include PASS/WARN/FAIL per section plus the original `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 

--- a/src/workflows/testarch/bmad-testarch-ci/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-v/step-01-validate.md
@@ -49,7 +49,7 @@ Use the artifact paths the user supplied with the Validate request. If none were
 
 Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
 
-Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{outputFile}` with both values. Atomically reserve that path using an exclusive-create operation that fails if the file already exists. A separate existence check followed by a normal write is forbidden. On collision, generate a fresh timestamp, resolve a new path, and retry exclusive creation until it succeeds. Initialize the reserved file with `validation_scope`, `run_timestamp`, `validated_artifacts`, and `status: IN_PROGRESS`. This run may update only the file it reserved. If the workflow stops, leave that reservation in place. Never delete, truncate, or reuse a report from another run. Always refuse to overwrite prior validation history.
 
 ### 2. Load Checklist
 
@@ -75,7 +75,7 @@ Scan all generated YAML workflow files for unsafe interpolation patterns inside 
 
 ### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
+Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the final validation report. Include PASS/WARN/FAIL per section plus the original `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 

--- a/src/workflows/testarch/bmad-testarch-ci/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{test_artifacts}/ci-validation-report.md'
+outputFile: '{test_artifacts}/ci-validation-report-{validation_scope}-{run_timestamp}.md'
 validationChecklist: '{skill-root}/checklist.md'
 ---
 
@@ -26,6 +26,7 @@ Validate outputs using the workflow checklist and record findings.
 
 - 🎯 Validate against `{validationChecklist}`
 - 🚫 Do not skip checks
+- 🚫 Never overwrite an existing validation report
 
 ## EXECUTION PROTOCOLS:
 
@@ -34,7 +35,7 @@ Validate outputs using the workflow checklist and record findings.
 
 ## CONTEXT BOUNDARIES:
 
-- Available context: workflow outputs and checklist
+- Available context: user-selected workflow outputs and checklist
 - Focus: validation only
 - Limits: do not modify outputs in this step
 
@@ -42,15 +43,23 @@ Validate outputs using the workflow checklist and record findings.
 
 **CRITICAL:** Follow this sequence exactly.
 
-### 1. Load Checklist
+### 1. Select Scope and Resolve Report Path
+
+Use the artifact paths the user supplied with the Validate request. If none were supplied, list the likely outputs for this workflow and ask which exact file or files to validate. When several candidates exist, do not guess.
+
+Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
+
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+
+### 2. Load Checklist
 
 Read `{validationChecklist}` and list all criteria.
 
-### 2. Validate Outputs
+### 3. Validate Outputs
 
 Evaluate outputs against each checklist item.
 
-### 2a. Script Injection Scan
+### 3a. Script Injection Scan
 
 Scan all generated YAML workflow files for unsafe interpolation patterns inside `run:` blocks.
 
@@ -64,9 +73,9 @@ Scan all generated YAML workflow files for unsafe interpolation patterns inside 
 
 **Safe patterns to ignore** (exempt from flagging): `${{ steps.*.outputs.* }}`, `${{ matrix.* }}`, `${{ runner.os }}`, `${{ github.sha }}`, `${{ github.ref }}`, `${{ secrets.* }}`, `${{ env.* }}` — these are safe from GitHub expression injection when used in `run:` blocks.
 
-### 3. Write Report
+### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
+Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 
@@ -74,6 +83,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 - Validation report written
 - All checklist items evaluated
+- All selected artifacts recorded in the report
 
 ### ❌ SYSTEM FAILURE:
 

--- a/src/workflows/testarch/bmad-testarch-framework/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{test_artifacts}/framework-validation-report.md'
+outputFile: '{test_artifacts}/framework-validation-report-{validation_scope}-{run_timestamp}.md'
 validationChecklist: '{skill-root}/checklist.md'
 ---
 
@@ -26,6 +26,7 @@ Validate outputs using the workflow checklist and record findings.
 
 - 🎯 Validate against `{validationChecklist}`
 - 🚫 Do not skip checks
+- 🚫 Never overwrite an existing validation report
 
 ## EXECUTION PROTOCOLS:
 
@@ -34,7 +35,7 @@ Validate outputs using the workflow checklist and record findings.
 
 ## CONTEXT BOUNDARIES:
 
-- Available context: workflow outputs and checklist
+- Available context: user-selected workflow outputs and checklist
 - Focus: validation only
 - Limits: do not modify outputs in this step
 
@@ -42,17 +43,25 @@ Validate outputs using the workflow checklist and record findings.
 
 **CRITICAL:** Follow this sequence exactly.
 
-### 1. Load Checklist
+### 1. Select Scope and Resolve Report Path
+
+Use the artifact paths the user supplied with the Validate request. If none were supplied, list the likely outputs for this workflow and ask which exact file or files to validate. When several candidates exist, do not guess.
+
+Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
+
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+
+### 2. Load Checklist
 
 Read `{validationChecklist}` and list all criteria.
 
-### 2. Validate Outputs
+### 3. Validate Outputs
 
 Evaluate outputs against each checklist item.
 
-### 3. Write Report
+### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
+Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 
@@ -60,6 +69,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 - Validation report written
 - All checklist items evaluated
+- All selected artifacts recorded in the report
 
 ### ❌ SYSTEM FAILURE:
 

--- a/src/workflows/testarch/bmad-testarch-framework/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-v/step-01-validate.md
@@ -49,7 +49,7 @@ Use the artifact paths the user supplied with the Validate request. If none were
 
 Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
 
-Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{outputFile}` with both values. Atomically reserve that path using an exclusive-create operation that fails if the file already exists. A separate existence check followed by a normal write is forbidden. On collision, generate a fresh timestamp, resolve a new path, and retry exclusive creation until it succeeds. Initialize the reserved file with `validation_scope`, `run_timestamp`, `validated_artifacts`, and `status: IN_PROGRESS`. This run may update only the file it reserved. If the workflow stops, leave that reservation in place. Never delete, truncate, or reuse a report from another run. Always refuse to overwrite prior validation history.
 
 ### 2. Load Checklist
 
@@ -61,7 +61,7 @@ Evaluate outputs against each checklist item.
 
 ### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
+Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the final validation report. Include PASS/WARN/FAIL per section plus the original `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{test_artifacts}/nfr-assess-validation-report.md'
+outputFile: '{test_artifacts}/nfr-assess-validation-report-{validation_scope}-{run_timestamp}.md'
 validationChecklist: '{skill-root}/checklist.md'
 ---
 
@@ -26,6 +26,7 @@ Validate outputs using the workflow checklist and record findings.
 
 - 🎯 Validate against `{validationChecklist}`
 - 🚫 Do not skip checks
+- 🚫 Never overwrite an existing validation report
 
 ## EXECUTION PROTOCOLS:
 
@@ -34,7 +35,7 @@ Validate outputs using the workflow checklist and record findings.
 
 ## CONTEXT BOUNDARIES:
 
-- Available context: workflow outputs and checklist
+- Available context: user-selected workflow outputs and checklist
 - Focus: validation only
 - Limits: do not modify outputs in this step
 
@@ -42,17 +43,25 @@ Validate outputs using the workflow checklist and record findings.
 
 **CRITICAL:** Follow this sequence exactly.
 
-### 1. Load Checklist
+### 1. Select Scope and Resolve Report Path
+
+Use the artifact paths the user supplied with the Validate request. If none were supplied, list the likely outputs for this workflow and ask which exact file or files to validate. When several candidates exist, do not guess.
+
+Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
+
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+
+### 2. Load Checklist
 
 Read `{validationChecklist}` and list all criteria.
 
-### 2. Validate Outputs
+### 3. Validate Outputs
 
 Evaluate outputs against each checklist item.
 
-### 3. Write Report
+### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
+Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 
@@ -60,6 +69,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 - Validation report written
 - All checklist items evaluated
+- All selected artifacts recorded in the report
 
 ### ❌ SYSTEM FAILURE:
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-v/step-01-validate.md
@@ -49,7 +49,7 @@ Use the artifact paths the user supplied with the Validate request. If none were
 
 Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
 
-Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{outputFile}` with both values. Atomically reserve that path using an exclusive-create operation that fails if the file already exists. A separate existence check followed by a normal write is forbidden. On collision, generate a fresh timestamp, resolve a new path, and retry exclusive creation until it succeeds. Initialize the reserved file with `validation_scope`, `run_timestamp`, `validated_artifacts`, and `status: IN_PROGRESS`. This run may update only the file it reserved. If the workflow stops, leave that reservation in place. Never delete, truncate, or reuse a report from another run. Always refuse to overwrite prior validation history.
 
 ### 2. Load Checklist
 
@@ -61,7 +61,7 @@ Evaluate outputs against each checklist item.
 
 ### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
+Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the final validation report. Include PASS/WARN/FAIL per section plus the original `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-v/step-01-validate.md
@@ -49,7 +49,7 @@ Use the artifact paths the user supplied with the Validate request. If none were
 
 Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
 
-Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{outputFile}` with both values. Atomically reserve that path using an exclusive-create operation that fails if the file already exists. A separate existence check followed by a normal write is forbidden. On collision, generate a fresh timestamp, resolve a new path, and retry exclusive creation until it succeeds. Initialize the reserved file with `validation_scope`, `run_timestamp`, `validated_artifacts`, and `status: IN_PROGRESS`. This run may update only the file it reserved. If the workflow stops, leave that reservation in place. Never delete, truncate, or reuse a report from another run. Always refuse to overwrite prior validation history.
 
 ### 2. Load Checklist
 
@@ -61,7 +61,7 @@ Evaluate outputs against each checklist item.
 
 ### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
+Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the final validation report. Include PASS/WARN/FAIL per section plus the original `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{test_artifacts}/test-design-validation-report.md'
+outputFile: '{test_artifacts}/test-design-validation-report-{validation_scope}-{run_timestamp}.md'
 validationChecklist: '{skill-root}/checklist.md'
 ---
 
@@ -26,6 +26,7 @@ Validate outputs using the workflow checklist and record findings.
 
 - 🎯 Validate against `{validationChecklist}`
 - 🚫 Do not skip checks
+- 🚫 Never overwrite an existing validation report
 
 ## EXECUTION PROTOCOLS:
 
@@ -34,7 +35,7 @@ Validate outputs using the workflow checklist and record findings.
 
 ## CONTEXT BOUNDARIES:
 
-- Available context: workflow outputs and checklist
+- Available context: user-selected workflow outputs and checklist
 - Focus: validation only
 - Limits: do not modify outputs in this step
 
@@ -42,17 +43,25 @@ Validate outputs using the workflow checklist and record findings.
 
 **CRITICAL:** Follow this sequence exactly.
 
-### 1. Load Checklist
+### 1. Select Scope and Resolve Report Path
+
+Use the artifact paths the user supplied with the Validate request. If none were supplied, list the likely outputs for this workflow and ask which exact file or files to validate. When several candidates exist, do not guess.
+
+Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
+
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+
+### 2. Load Checklist
 
 Read `{validationChecklist}` and list all criteria.
 
-### 2. Validate Outputs
+### 3. Validate Outputs
 
 Evaluate outputs against each checklist item.
 
-### 3. Write Report
+### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
+Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 
@@ -60,6 +69,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 - Validation report written
 - All checklist items evaluated
+- All selected artifacts recorded in the report
 
 ### ❌ SYSTEM FAILURE:
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{test_artifacts}/test-review-validation-report.md'
+outputFile: '{test_artifacts}/test-review-validation-report-{validation_scope}-{run_timestamp}.md'
 validationChecklist: '{skill-root}/checklist.md'
 ---
 
@@ -26,6 +26,7 @@ Validate outputs using the workflow checklist and record findings.
 
 - 🎯 Validate against `{validationChecklist}`
 - 🚫 Do not skip checks
+- 🚫 Never overwrite an existing validation report
 
 ## EXECUTION PROTOCOLS:
 
@@ -34,7 +35,7 @@ Validate outputs using the workflow checklist and record findings.
 
 ## CONTEXT BOUNDARIES:
 
-- Available context: workflow outputs and checklist
+- Available context: user-selected workflow outputs and checklist
 - Focus: validation only
 - Limits: do not modify outputs in this step
 
@@ -42,17 +43,25 @@ Validate outputs using the workflow checklist and record findings.
 
 **CRITICAL:** Follow this sequence exactly.
 
-### 1. Load Checklist
+### 1. Select Scope and Resolve Report Path
+
+Use the artifact paths the user supplied with the Validate request. If none were supplied, list the likely outputs for this workflow and ask which exact file or files to validate. When several candidates exist, do not guess.
+
+Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
+
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+
+### 2. Load Checklist
 
 Read `{validationChecklist}` and list all criteria.
 
-### 2. Validate Outputs
+### 3. Validate Outputs
 
 Evaluate outputs against each checklist item.
 
-### 3. Write Report
+### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
+Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 
@@ -60,6 +69,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 - Validation report written
 - All checklist items evaluated
+- All selected artifacts recorded in the report
 
 ### ❌ SYSTEM FAILURE:
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-v/step-01-validate.md
@@ -49,7 +49,7 @@ Use the artifact paths the user supplied with the Validate request. If none were
 
 Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
 
-Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{outputFile}` with both values. Atomically reserve that path using an exclusive-create operation that fails if the file already exists. A separate existence check followed by a normal write is forbidden. On collision, generate a fresh timestamp, resolve a new path, and retry exclusive creation until it succeeds. Initialize the reserved file with `validation_scope`, `run_timestamp`, `validated_artifacts`, and `status: IN_PROGRESS`. This run may update only the file it reserved. If the workflow stops, leave that reservation in place. Never delete, truncate, or reuse a report from another run. Always refuse to overwrite prior validation history.
 
 ### 2. Load Checklist
 
@@ -61,7 +61,7 @@ Evaluate outputs against each checklist item.
 
 ### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
+Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the final validation report. Include PASS/WARN/FAIL per section plus the original `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-v/step-01-validate.md
@@ -1,7 +1,7 @@
 ---
 name: 'step-01-validate'
 description: 'Validate workflow outputs against checklist'
-outputFile: '{test_artifacts}/trace-validation-report.md'
+outputFile: '{test_artifacts}/trace-validation-report-{validation_scope}-{run_timestamp}.md'
 validationChecklist: '{skill-root}/checklist.md'
 ---
 
@@ -26,6 +26,7 @@ Validate outputs using the workflow checklist and record findings.
 
 - 🎯 Validate against `{validationChecklist}`
 - 🚫 Do not skip checks
+- 🚫 Never overwrite an existing validation report
 
 ## EXECUTION PROTOCOLS:
 
@@ -34,7 +35,7 @@ Validate outputs using the workflow checklist and record findings.
 
 ## CONTEXT BOUNDARIES:
 
-- Available context: workflow outputs and checklist
+- Available context: user-selected workflow outputs and checklist
 - Focus: validation only
 - Limits: do not modify outputs in this step
 
@@ -42,17 +43,25 @@ Validate outputs using the workflow checklist and record findings.
 
 **CRITICAL:** Follow this sequence exactly.
 
-### 1. Load Checklist
+### 1. Select Scope and Resolve Report Path
+
+Use the artifact paths the user supplied with the Validate request. If none were supplied, list the likely outputs for this workflow and ask which exact file or files to validate. When several candidates exist, do not guess.
+
+Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
+
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+
+### 2. Load Checklist
 
 Read `{validationChecklist}` and list all criteria.
 
-### 2. Validate Outputs
+### 3. Validate Outputs
 
 Evaluate outputs against each checklist item.
 
-### 3. Write Report
+### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
+Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 
@@ -60,6 +69,7 @@ Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section.
 
 - Validation report written
 - All checklist items evaluated
+- All selected artifacts recorded in the report
 
 ### ❌ SYSTEM FAILURE:
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-v/step-01-validate.md
@@ -49,7 +49,7 @@ Use the artifact paths the user supplied with the Validate request. If none were
 
 Read the selected artifacts. Derive `validation_scope` from their shared story, epic, system, pull request, or other meaningful scope. Use an artifact basename without its extension when no broader scope is available. Normalize the value to lowercase ASCII with only letters, numbers, and single hyphens. Remove leading and trailing hyphens. Ask for a short scope label if normalization leaves an empty value.
 
-Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format. Resolve `{outputFile}` with both values, then check whether that exact path exists. If it exists, generate a fresh timestamp and resolve the path again. Never delete, truncate, or reuse the existing file. Always refuse to overwrite prior validation history.
+Set `run_timestamp` to the current UTC time with milliseconds in `YYYYMMDDTHHmmssSSSZ` format and resolve `{outputFile}` with both values. Atomically reserve that path using an exclusive-create operation that fails if the file already exists. A separate existence check followed by a normal write is forbidden. On collision, generate a fresh timestamp, resolve a new path, and retry exclusive creation until it succeeds. Initialize the reserved file with `validation_scope`, `run_timestamp`, `validated_artifacts`, and `status: IN_PROGRESS`. This run may update only the file it reserved. If the workflow stops, leave that reservation in place. Never delete, truncate, or reuse a report from another run. Always refuse to overwrite prior validation history.
 
 ### 2. Load Checklist
 
@@ -61,7 +61,7 @@ Evaluate outputs against each checklist item.
 
 ### 4. Write Report
 
-Write a validation report to `{outputFile}` with PASS/WARN/FAIL per section. Include `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
+Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the final validation report. Include PASS/WARN/FAIL per section plus the original `validation_scope`, `run_timestamp`, and `validated_artifacts` metadata. Record every selected artifact using its exact project-relative path.
 
 ## 🚨 SYSTEM SUCCESS/FAILURE METRICS:
 

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -382,6 +382,40 @@ async function runTests() {
             assert(stepContent.includes("workflowPath: '{skill-root}'"), `${stepLabel} anchors workflowPath to {skill-root}`);
           }
 
+          if (stepDir === 'steps-v') {
+            const reportPathMatch = frontmatter.match(/^(?:outputFile|validationReport):\s*['"]([^'"]+)['"]/m);
+            assert(frontmatter.includes('{run_timestamp}'), `${stepLabel} gives every validation run a timestamped report path`);
+            assert(Boolean(reportPathMatch), `${stepLabel} declares a parseable validation report path`);
+            assert(
+              stepContent.includes('refuse to overwrite') || stepContent.includes('Never overwrite'),
+              `${stepLabel} refuses to overwrite an existing validation report`,
+            );
+
+            if (dirName !== 'bmad-teach-me-testing') {
+              assert(
+                frontmatter.includes('{validation_scope}'),
+                `${stepLabel} identifies the artifact scope in the validation report path`,
+              );
+              assert(stepContent.includes('selected artifacts'), `${stepLabel} records the selected artifacts in the validation report`);
+
+              if (reportPathMatch) {
+                const reportPathTemplate = reportPathMatch[1];
+                const epicNineReport = reportPathTemplate
+                  .replace('{validation_scope}', 'epic-9')
+                  .replace('{run_timestamp}', '20260824T120000000Z');
+                const epicTenReport = reportPathTemplate
+                  .replace('{validation_scope}', 'epic-10')
+                  .replace('{run_timestamp}', '20260824T120000000Z');
+                const epicNineRerun = reportPathTemplate
+                  .replace('{validation_scope}', 'epic-9')
+                  .replace('{run_timestamp}', '20260824T120001000Z');
+
+                assert(epicNineReport !== epicTenReport, `${stepLabel} keeps parallel epic validation reports separate`);
+                assert(epicNineReport !== epicNineRerun, `${stepLabel} keeps repeated validation reports in run history`);
+              }
+            }
+          }
+
           if (frontmatter.includes('knowledgeIndex:')) {
             const knowledgeIndexMatch = frontmatter.match(/^knowledgeIndex:\s*['"]([^'"]+)['"]/m);
             assert(Boolean(knowledgeIndexMatch), `${stepLabel} declares a parseable knowledgeIndex`);

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -384,22 +384,26 @@ async function runTests() {
 
           if (stepDir === 'steps-v') {
             const reportPathMatch = frontmatter.match(/^(?:outputFile|validationReport):\s*['"]([^'"]+)['"]/m);
-            assert(frontmatter.includes('{run_timestamp}'), `${stepLabel} gives every validation run a timestamped report path`);
             assert(Boolean(reportPathMatch), `${stepLabel} declares a parseable validation report path`);
+            const reportPathTemplate = reportPathMatch ? reportPathMatch[1] : '';
+            assert(reportPathTemplate.includes('{run_timestamp}'), `${stepLabel} gives every validation run a timestamped report path`);
             assert(
               stepContent.includes('refuse to overwrite') || stepContent.includes('Never overwrite'),
               `${stepLabel} refuses to overwrite an existing validation report`,
             );
+            assert(
+              stepContent.includes('Atomically reserve') && stepContent.includes('exclusive-create operation'),
+              `${stepLabel} claims its validation report path atomically`,
+            );
 
             if (dirName !== 'bmad-teach-me-testing') {
               assert(
-                frontmatter.includes('{validation_scope}'),
+                reportPathTemplate.includes('{validation_scope}'),
                 `${stepLabel} identifies the artifact scope in the validation report path`,
               );
               assert(stepContent.includes('selected artifacts'), `${stepLabel} records the selected artifacts in the validation report`);
 
               if (reportPathMatch) {
-                const reportPathTemplate = reportPathMatch[1];
                 const epicNineReport = reportPathTemplate
                   .replace('{validation_scope}', 'epic-9')
                   .replace('{run_timestamp}', '20260824T120000000Z');


### PR DESCRIPTION
## Summary

- select and record the exact artifact scope before validation
- write scope-specific reports with millisecond UTC run timestamps
- refuse to overwrite an existing validation report across all nine validate workflows
- document the filename contract and protect it with regression coverage

## Reproduction

The new installation contract checks failed 34 assertions before the workflow changes. Every validate workflow lacked a unique run timestamp or overwrite guard. The eight artifact workflows also lacked a target scope and artifact manifest. The same test now proves that separate epics and repeated runs resolve to distinct report paths.

## Validation

- npm test
- npm run docs:validate-links
- npm run docs:build

Closes #140