### PR TITLE
fix(skills): pass --project-root to the customization resolver

### DIFF
--- a/src/agents/bmad-tea/SKILL.md
+++ b/src/agents/bmad-tea/SKILL.md
@@ -20,7 +20,7 @@ You are Murat, the Master Test Architect and Quality Advisor. You lead risk-base
 
 ### Step 1: Resolve the Agent Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key agent`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key agent`
 
 **If the script fails**, resolve the `agent` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-teach-me-testing/SKILL.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/SKILL.md
@@ -25,7 +25,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-05-completion.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-c/step-05-completion.md
@@ -336,7 +336,7 @@ Workflow ends here. User can run the workflow again to re-take sessions or explo
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-e/step-e-02-apply-edits.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-e/step-e-02-apply-edits.md
@@ -123,7 +123,7 @@ The teach-me-testing workflow has been updated.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
+++ b/src/workflows/testarch/bmad-teach-me-testing/steps-v/step-v-01-validate.md
@@ -271,7 +271,7 @@ Workflow is usable but could be improved.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-atdd/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-05-validate-and-complete.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-c/step-05-validate-and-complete.md
@@ -116,7 +116,7 @@ Report:
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-atdd/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-atdd/steps-v/step-01-validate.md
@@ -78,7 +78,7 @@ Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the fi
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-automate/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-automate/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-automate/steps-c/step-04-validate-and-summarize.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-c/step-04-validate-and-summarize.md
@@ -113,7 +113,7 @@ Name in the same section any RECOMMENDED utility the run wanted but could not wi
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-automate/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-automate/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-automate/steps-v/step-01-validate.md
@@ -78,7 +78,7 @@ Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the fi
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-ci/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-ci/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-ci/steps-c/step-04-validate-and-summary.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-c/step-04-validate-and-summary.md
@@ -93,7 +93,7 @@ Report:
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-ci/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-ci/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-ci/steps-v/step-01-validate.md
@@ -92,7 +92,7 @@ Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the fi
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-framework/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-framework/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-framework/steps-c/step-05-validate-and-summary.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-c/step-05-validate-and-summary.md
@@ -94,7 +94,7 @@ Report:
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-framework/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-framework/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-framework/steps-v/step-01-validate.md
@@ -78,7 +78,7 @@ Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the fi
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-nfr/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-05-generate-report.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-c/step-05-generate-report.md
@@ -109,7 +109,7 @@ Report:
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-nfr/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-nfr/steps-v/step-01-validate.md
@@ -78,7 +78,7 @@ Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the fi
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-05-generate-output.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-c/step-05-generate-output.md
@@ -234,7 +234,7 @@ Summarize:
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-design/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-test-design/steps-v/step-01-validate.md
@@ -78,7 +78,7 @@ Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the fi
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-review/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-04-generate-report.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-c/step-04-generate-report.md
@@ -115,7 +115,7 @@ Report:
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-test-review/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-test-review/steps-v/step-01-validate.md
@@ -78,7 +78,7 @@ Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the fi
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-trace/SKILL.md
+++ b/src/workflows/testarch/bmad-testarch-trace/SKILL.md
@@ -23,7 +23,7 @@ You will continue to operate with your given name, identity, and communication_s
 
 ### Step 1: Resolve the Workflow Block
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow`
 
 **If the script fails**, resolve the `workflow` block yourself by reading these three files in base → team → user order and applying the same structural merge rules as the resolver:
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-c/step-05-gate-decision.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-c/step-05-gate-decision.md
@@ -788,7 +788,7 @@ Then append the gate decision summary (from section 5 above) to the end of the e
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-e/step-02-apply-edit.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-e/step-02-apply-edit.md
@@ -61,7 +61,7 @@ Summarize the edits applied.
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/src/workflows/testarch/bmad-testarch-trace/steps-v/step-01-validate.md
+++ b/src/workflows/testarch/bmad-testarch-trace/steps-v/step-01-validate.md
@@ -78,7 +78,7 @@ Replace the `IN_PROGRESS` body in this run's reserved `{outputFile}` with the fi
 
 ## On Complete
 
-Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --key workflow.on_complete`
+Run: `uv run {project-root}/_bmad/scripts/resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow.on_complete`
 
 If the resolver succeeds and returns a non-empty `workflow.on_complete`, execute that value as the final terminal instruction before exiting.
 

--- a/test/test-installation-components.js
+++ b/test/test-installation-components.js
@@ -273,7 +273,7 @@ async function runTests() {
         assert(skillContent && skillContent.trim().length > 0, `${dirName}/SKILL.md is not empty`);
         assert(skillContent.includes('## On Activation'), `${dirName}/SKILL.md has On Activation section`);
         assert(
-          skillContent.includes('resolve_customization.py --skill {skill-root} --key workflow'),
+          skillContent.includes('resolve_customization.py --skill {skill-root} --project-root {project-root} --key workflow'),
           `${dirName}/SKILL.md resolves the workflow customization block`,
         );
         assert(skillContent.includes('{workflow.activation_steps_prepend}'), `${dirName}/SKILL.md executes prepend activation steps`);


### PR DESCRIPTION
Adds `--project-root {project-root}` to all 37 `resolve_customization.py` invocation sites across 37 files — the testarch workflows and their `steps-c/`, `steps-v/`, `steps-e/` step files.

One extra edit: `test/test-installation-components.js:276` asserts on the literal invocation string, so the assertion moves with the skills. `npm run test:install` passes (853/853).

## Why

`resolve_customization.py` inferred the project root when `--project-root` was absent, walking up from the **skill's installed directory**. For a skill installed under the user's home that walk reaches `~` — and a user-level install's `~/_bmad` made home look like the project. Team overrides in the real project were silently ignored: no error, no warning, just shipped defaults.

The resolver itself is fixed in bmad-code-org/BMAD-METHOD#2802. **That is what actually repairs existing installs** — this module ships no copy of the script and calls core's at `{project-root}/_bmad/scripts/`, so it inherits the fix on upgrade with nothing to do here.

This PR is the hardening half. Passing the root explicitly leaves nothing to infer, and matches `resolve_config.py`, which has always required the flag.

## Safety

No behaviour change wherever the inference already landed correctly, which is the common case. `--project-root` has always existed, so there is no version skew in either direction: new skill text works against an old resolver, and old text against the new one. This can merge before or after #2802.

Refs bmad-code-org/BMAD-METHOD#2796