### PR TITLE
fix(evals): one default runner, and a supported Node floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The `test-review` eval harness defaulted to the `codex` runner while `eval-fragment-selection` and `eval-trace` defaulted to `claude`. All three default to `claude` now.
+- `engines.node` is `>=22.0.0`, the current LTS and the one before it. It said `>=20.0.0`, which is older than any Node line still under long-term support.
 - `redactArgs` drops a credential-shaped value anywhere in an argument. The pattern was start-anchored and was never applied to the value half of `--flag=value`, so `--extra=sk-live-abc`, `--header=ghp_...`, `Authorization: Bearer ghp_...` and `?token=ghp_...` all reached a result file CI uploads. A boundary in front of the prefix keeps `risk-based` and `task-runner` intact.
 - `tools/generate-contracts.js` hashes through the one digest helper in `test/lib/eval-record.js`, which length-prefixes each file. Concatenating bytes let a byte moved from the tail of one step file to the head of the next leave the digest unchanged, and `bmad-testarch-ci` pins a multi-file list. Every `sourceSpecDigest` moved.
 - Behavior B-003 grades `material`. Missing every planted HIGH defect graded `low`, below one out-of-scope finding. The grade is derived from the registry severity of the group's rows, on the rule that CRITICAL carries its own recall gate and everything else feeds the pooled one.

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "zod-to-json-schema": "3.25.1"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/test/eval-test-review.js
+++ b/test/eval-test-review.js
@@ -173,7 +173,7 @@ function parseArgs(argv) {
       }
     }
   }
-  if (agents.length === 0) agents.push('codex');
+  if (agents.length === 0) agents.push('claude');
   if (agents.includes('custom') && !agentCmd) fatal(2, '--agent custom requires --agent-cmd');
   if (agents.includes('custom') && model) {
     fatal(2, '--model is not supported by --agent custom; pass the runner model through --agent-arg');


### PR DESCRIPTION
`test-review` defaulted to the `codex` runner while `eval-fragment-selection` and `eval-trace` defaulted to `claude`. Nobody chose that; all three default to `claude` now.

`engines.node` said `>=20.0.0`, older than any Node line still under long-term support. It is `>=22.0.0`, the current LTS and the one before it.