### PR TITLE
chore: move to eval-quality 1.4.0 and record what it changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `eval-quality` moves from 1.3.0 to 1.4.0, which closes three findings this repository raised against it, and the probe corpora record what changed. Measured on the stored replay across the two versions: `test-review`'s five plants that had failed pre-flight on `seeded-faults-scoped` with a null verdict and exit 3 now pass pre-flight and score, taking the suite's defect class from four exercised and four caught to nine and nine at a rate of 1; `trace`'s O-023 and O-024 move from `abstained` to `passed-clean-control`, because a bare `count-tolerance` with `expected: 0` now counts a collection observed to be present and empty; and `trace`'s three defect probes report `condition-artifact-channel-contract-local`, the reason AD-9's gate refused them, where before a rejected probe surfaced only as `infrastructure-error` and exit 3. `expected-strength.json` records a `qualification` field per probe, so a rejection that changes its reason shows up as a diff.
+
+### Fixed
+
+- Four passages describing limitations that no longer exist. `test/probes/README.md` and `docs/explanation/eval-quality-command-adapter.md` each said a rejected probe carries no reason across the boundary; the adapter document also said "this collection is empty" has no spelling, and argued that no leg TEA could add repairs `seeded-faults-scoped` firing on a leg carrying the fault leg's own request. All four are rewritten against what 1.4.0 does, with the measured before and after. Two findings stay open and belong to TEA rather than to `eval-quality`: `trace`'s witness fires on `witness-gate-withheld`, a leg that issues a different request and receives a different answer, which is a real scoping problem in the trace contract; and its three defect probes address a file the command wrote, which the qualification gate refuses by design.
+
 ## [1.25.0] - 2026-09-09
 
 ### Added

--- a/docs/explanation/eval-quality-command-adapter.md
+++ b/docs/explanation/eval-quality-command-adapter.md
@@ -162,34 +162,65 @@ trace plants: the live pre-flight reports `D-001: the manifestation witness fire
 "witness-gate-evaluated"`. The four review plants in the file no witness leg reads pre-flight cleanly
 and score, and the defect class catches all four.
 
-No leg TEA can add repairs it, and the reason is sharper than "a plant sits in a file a witness
+No leg TEA could add repaired it, and the reason was sharper than "a plant sits in a file a witness
 reads". For those five plants the fault leg's request is byte for byte the sensitivity leg's request:
 the same executable, the same `--files`, the same `--json`, the same `--agent`. The observation cache
-collapses them into one spawn for exactly that reason. So the check resolves the manifestation
+collapses them into one spawn for exactly that reason. So the check resolved the manifestation
 relation against a run identical to the fault run, and no relation true on the one can be false on
-the other. Adding a leg that reads an unplanted fixture changes nothing, because the check fails on a
-leg that fires rather than on the absence of a leg that does not, and adding legs can only add ways
-to fire. Making the seeded witness leg read an unplanted fixture is not available either: the
+the other. Adding a leg that reads an unplanted fixture changed nothing, because the check fails on a
+leg that fires rather than on the absence of a leg that does not, and adding legs could only add ways
+to fire. Making the seeded witness leg read an unplanted fixture was not available either: the
 differential it asserts is that two file lists produce different severity counts, and two unplanted
 lists produce the same counts, so the witness would fail instead. The one remaining shape, a witness
 whose relation compares the `reviewedFiles` the verdict echoes back, is the "the evidence contains
 the string I sent" condition the probe-side qualification gate exists to reject, and authoring it
 contract-side to get a green pre-flight would be gaming the witness.
 
-**"This collection is empty" has no spelling.** The evaluator intercepts an empty array on every
-quantifier and on every single-operand leaf and returns `insufficient-evidence` with an
-`empty-collection` condition before the operator runs, so `count-tolerance` with `expected: 0` never
-counts and `deep-equality` against a literal `[]` never compares. Two of `trace`'s oracles make
-exactly that claim about its clean set, and both abstain on the run they were written to confirm.
-`count-tolerance` is the spelling this repository now uses, because it is the claim the oracle is
-making and it starts working the day an empty collection counts as evidence for a cardinality check.
+TEA raised it upstream, and 1.4.0 fixes it in the reducer. A clean leg is dropped when it issued the
+fault leg's request and received the fault leg's answer, compared over the request with the
+correlation identifier neutralised and over the projected evidence with the observation identifier
+neutralised. Both halves are required: dropping on the answer alone would discard AD-10's own worked
+example of two distinct nonexistent identifiers both returning 404, which are the legs the check
+exists to read. A check left with no clean leg to examine now fails and names why, where it reported
+satisfied before.
 
-**A rejected probe carries no reason across the boundary.** The qualification gate computes a closed
-list of twenty reason codes and none of them reaches the evidence artifact or any published export.
-A probe the gate rejects surfaces as `infrastructure-error` on every oracle and exit 3, and a corpus
-author reading that has nothing to act on. Reading the reasons needs `qualifyProbe`, which is not on
-the exports map, and that would be the third reach into `dist/` this document already records two of.
-TEA does not take it.
+Measured on the stored replay across the two versions, `test-review`'s five plants move from
+`preflight: failed: seeded-faults-scoped` with a null verdict and exit 3 to `preflight: passed`,
+`CONCERNS`, exit 0, each carrying its own strength vector. The suite's defect class goes from four
+exercised and four caught to nine and nine, still at a rate of 1. `expected-strength.json` records
+the move.
+
+`trace`'s three plants still fail, and that is the fix working rather than failing. Their witness
+fires on `witness-gate-withheld`, a leg that issues a different request and receives a different
+answer, so the reducer keeps it in the examined set and the check reports a real scoping problem in
+the trace contract. It is a finding about the contract and it is still open.
+
+**"This collection is empty" has a spelling, as of 1.4.0.** Through 1.3.0 the evaluator intercepted
+an empty array on every quantifier and every single-operand leaf and returned `insufficient-evidence`
+with an `empty-collection` condition before the operator ran, so `count-tolerance` with `expected: 0`
+never counted. `trace`'s O-023 and O-024 make exactly that claim about its clean set, and both
+abstained on the run they were written to confirm. TEA raised it upstream and 1.4.0 exempts the three
+operators that read a property of the collection itself: `count-tolerance` reads its cardinality,
+`existence` and `absence` read its presence. Measured on the stored replay across the two versions,
+O-023 and O-024 move from `abstained` to `passed-clean-control`, so `count-tolerance` was the right
+spelling to have committed to.
+
+One limit is worth knowing before writing a new oracle. Every quantifier still abstains over an empty
+collection, which is AD-4's whole purpose and is why `trace`'s five `for-any` oracles over the seeded
+export still abstain on a clean run: they ask whether some element exists, and an empty collection is
+an honest "nothing was checked". `deep-equality` against a literal `[]` also still abstains, so the
+two spellings of "this collection is empty" disagree. eval-quality records that disagreement in AD-4
+rather than hiding it. The bare `count-tolerance` assertion is the one to write.
+
+**A rejected probe names its reason, as of 1.4.0.** The qualification gate computes a closed list of
+twenty reason codes. Through 1.3.0 none of them reached the evidence artifact or any published
+export, so a probe the gate rejected surfaced as `infrastructure-error` and exit 3 and a corpus
+author reading that had nothing to act on. Reading the reasons meant calling `qualifyProbe`, which
+was off the exports map, and taking it would have been the third reach into `dist/` this document
+already records two of. TEA raised that upstream instead. `runScore` now returns `qualification`
+beside the artifact and the ladder, `QUALIFICATION_FAILURES` publishes the closed set, and
+`test-probe-corpus` records the codes per probe in `expected-strength.json`. No reach into `dist/`
+was needed and the count stays at two.
 
 ### What the scoring half says about TEA's contracts
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "eslint-plugin-n": "^17.21.3",
         "eslint-plugin-unicorn": "^60.0.0",
         "eslint-plugin-yml": "^1.18.0",
-        "eval-quality": "1.3.0",
+        "eval-quality": "1.4.0",
         "husky": "^9.1.7",
         "jest": "^30.0.4",
         "lint-staged": "^16.1.1",
@@ -7241,9 +7241,9 @@
       }
     },
     "node_modules/eval-quality": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eval-quality/-/eval-quality-1.3.0.tgz",
-      "integrity": "sha512-3LWJZs3M9Nzx8NTgNrsrdI3V3QMmtEuVvOtsYs+8OraUE53LgK1WJ4aPqqCvKj2rEaIwPfmzn3Xieco5DakD/A==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/eval-quality/-/eval-quality-1.4.0.tgz",
+      "integrity": "sha512-/6gsNLsGYgnYiAc+GXRX2TvV/Z4hQicYIYNjSzSk5XjRLHUdQIWuhMMM46LAlmRF27hoAKdtgl1B5vff+Rg3cA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "eslint-plugin-n": "^17.21.3",
     "eslint-plugin-unicorn": "^60.0.0",
     "eslint-plugin-yml": "^1.18.0",
-    "eval-quality": "1.3.0",
+    "eval-quality": "1.4.0",
     "husky": "^9.1.7",
     "jest": "^30.0.4",
     "lint-staged": "^16.1.1",

--- a/test/probes/README.md
+++ b/test/probes/README.md
@@ -71,9 +71,13 @@ signature that says something true about their plants is refused, and the refusa
 `expected-strength.json` rather than replaced by an `exit-code` signature that would qualify and
 discriminate nothing.
 
-**A rejected probe carries no reason across the boundary.** The qualification gate computes a closed
-list of reason codes, and none of them reaches the evidence artifact or any published export. A
-probe the gate rejects surfaces only as `infrastructure-error` on every oracle and an exit code of 3.
+**A rejected probe now names its reason.** The qualification gate computes a closed list of twenty
+reason codes. Through eval-quality 1.3.0 none of them reached the evidence artifact or any published
+export, so a rejected probe surfaced only as `infrastructure-error` and an exit code of 3, and a
+corpus author had nothing to act on. From 1.4.0 `runScore` returns `qualification` beside the
+artifact and the ladder, and `expected-strength.json` records the codes per probe. The reason still
+stays off the evidence artifact, which is deliberate: it is a fact about the probe rather than about
+the run.
 
 ## What the scoring half reports about the contracts
 

--- a/test/probes/expected-strength.json
+++ b/test/probes/expected-strength.json
@@ -4,8 +4,8 @@
     "probeCount": 11,
     "strength": {
       "defect": {
-        "exercised": 4,
-        "caught": 4,
+        "exercised": 9,
+        "caught": 9,
         "rate": 1
       },
       "gameability": {
@@ -21,51 +21,116 @@
         "probeClass": "defect",
         "expectedClean": false,
         "behaviorId": "B-001",
-        "preflight": "failed: seeded-faults-scoped",
-        "verdict": null,
-        "exitCode": 3,
-        "basis": ["pre-flight verdict did not pass"],
-        "strength": null
+        "preflight": "passed",
+        "verdict": "CONCERNS",
+        "exitCode": 0,
+        "basis": [
+          "coverage gap malformed-input unsatisfied at or above the severity floor",
+          "coverage gap state-change-read-back unsatisfied at or above the severity floor",
+          "coverage gap whole-body unsatisfied at or above the severity floor"
+        ],
+        "qualification": null,
+        "strength": {
+          "defect": {
+            "caught": 1,
+            "exercised": 1,
+            "rate": 1
+          },
+          "gameability": null,
+          "zero-action": null
+        }
       },
       "P-002": {
         "probeClass": "defect",
         "expectedClean": false,
         "behaviorId": "B-002",
-        "preflight": "failed: seeded-faults-scoped",
-        "verdict": null,
-        "exitCode": 3,
-        "basis": ["pre-flight verdict did not pass"],
-        "strength": null
+        "preflight": "passed",
+        "verdict": "CONCERNS",
+        "exitCode": 0,
+        "basis": [
+          "coverage gap malformed-input unsatisfied at or above the severity floor",
+          "coverage gap state-change-read-back unsatisfied at or above the severity floor",
+          "coverage gap whole-body unsatisfied at or above the severity floor"
+        ],
+        "qualification": null,
+        "strength": {
+          "defect": {
+            "caught": 1,
+            "exercised": 1,
+            "rate": 1
+          },
+          "gameability": null,
+          "zero-action": null
+        }
       },
       "P-003": {
         "probeClass": "defect",
         "expectedClean": false,
         "behaviorId": "B-003",
-        "preflight": "failed: seeded-faults-scoped",
-        "verdict": null,
-        "exitCode": 3,
-        "basis": ["pre-flight verdict did not pass"],
-        "strength": null
+        "preflight": "passed",
+        "verdict": "CONCERNS",
+        "exitCode": 0,
+        "basis": [
+          "coverage gap malformed-input unsatisfied at or above the severity floor",
+          "coverage gap state-change-read-back unsatisfied at or above the severity floor",
+          "coverage gap whole-body unsatisfied at or above the severity floor"
+        ],
+        "qualification": null,
+        "strength": {
+          "defect": {
+            "caught": 1,
+            "exercised": 1,
+            "rate": 1
+          },
+          "gameability": null,
+          "zero-action": null
+        }
       },
       "P-004": {
         "probeClass": "defect",
         "expectedClean": false,
         "behaviorId": "B-004",
-        "preflight": "failed: seeded-faults-scoped",
-        "verdict": null,
-        "exitCode": 3,
-        "basis": ["pre-flight verdict did not pass"],
-        "strength": null
+        "preflight": "passed",
+        "verdict": "CONCERNS",
+        "exitCode": 0,
+        "basis": [
+          "coverage gap malformed-input unsatisfied at or above the severity floor",
+          "coverage gap state-change-read-back unsatisfied at or above the severity floor",
+          "coverage gap whole-body unsatisfied at or above the severity floor"
+        ],
+        "qualification": null,
+        "strength": {
+          "defect": {
+            "caught": 1,
+            "exercised": 1,
+            "rate": 1
+          },
+          "gameability": null,
+          "zero-action": null
+        }
       },
       "P-005": {
         "probeClass": "defect",
         "expectedClean": false,
         "behaviorId": "B-005",
-        "preflight": "failed: seeded-faults-scoped",
-        "verdict": null,
-        "exitCode": 3,
-        "basis": ["pre-flight verdict did not pass"],
-        "strength": null
+        "preflight": "passed",
+        "verdict": "CONCERNS",
+        "exitCode": 0,
+        "basis": [
+          "coverage gap malformed-input unsatisfied at or above the severity floor",
+          "coverage gap state-change-read-back unsatisfied at or above the severity floor",
+          "coverage gap whole-body unsatisfied at or above the severity floor"
+        ],
+        "qualification": null,
+        "strength": {
+          "defect": {
+            "caught": 1,
+            "exercised": 1,
+            "rate": 1
+          },
+          "gameability": null,
+          "zero-action": null
+        }
       },
       "P-006": {
         "probeClass": "defect",
@@ -79,6 +144,7 @@
           "coverage gap state-change-read-back unsatisfied at or above the severity floor",
           "coverage gap whole-body unsatisfied at or above the severity floor"
         ],
+        "qualification": null,
         "strength": {
           "defect": {
             "caught": 1,
@@ -101,6 +167,7 @@
           "coverage gap state-change-read-back unsatisfied at or above the severity floor",
           "coverage gap whole-body unsatisfied at or above the severity floor"
         ],
+        "qualification": null,
         "strength": {
           "defect": {
             "caught": 1,
@@ -123,6 +190,7 @@
           "coverage gap state-change-read-back unsatisfied at or above the severity floor",
           "coverage gap whole-body unsatisfied at or above the severity floor"
         ],
+        "qualification": null,
         "strength": {
           "defect": {
             "caught": 1,
@@ -145,6 +213,7 @@
           "coverage gap state-change-read-back unsatisfied at or above the severity floor",
           "coverage gap whole-body unsatisfied at or above the severity floor"
         ],
+        "qualification": null,
         "strength": {
           "defect": {
             "caught": 1,
@@ -167,6 +236,7 @@
           "coverage gap state-change-read-back unsatisfied at or above the severity floor",
           "coverage gap whole-body unsatisfied at or above the severity floor"
         ],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": null,
@@ -181,6 +251,7 @@
         "verdict": null,
         "exitCode": 3,
         "basis": ["oracle resolved infrastructure-error"],
+        "qualification": ["condition-artifact-channel-contract-local"],
         "strength": null
       }
     }
@@ -207,6 +278,7 @@
         "verdict": null,
         "exitCode": 3,
         "basis": ["oracle resolved infrastructure-error", "pre-flight verdict did not pass"],
+        "qualification": ["condition-artifact-channel-contract-local"],
         "strength": null
       },
       "P-002": {
@@ -217,6 +289,7 @@
         "verdict": null,
         "exitCode": 3,
         "basis": ["oracle resolved infrastructure-error", "pre-flight verdict did not pass"],
+        "qualification": ["condition-artifact-channel-contract-local"],
         "strength": null
       },
       "P-003": {
@@ -227,6 +300,7 @@
         "verdict": null,
         "exitCode": 3,
         "basis": ["oracle resolved infrastructure-error", "pre-flight verdict did not pass"],
+        "qualification": ["condition-artifact-channel-contract-local"],
         "strength": null
       },
       "P-004": {
@@ -237,6 +311,7 @@
         "verdict": "FAIL",
         "exitCode": 2,
         "basis": ["oracle resolved abstained at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": null,
@@ -267,6 +342,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": {
@@ -285,6 +361,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": null,
@@ -315,6 +392,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": {
@@ -333,6 +411,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": null,
@@ -363,6 +442,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": {
@@ -381,6 +461,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": null,
@@ -411,6 +492,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": {
@@ -429,6 +511,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": null,
@@ -459,6 +542,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": {
@@ -477,6 +561,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": null,
@@ -507,6 +592,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": {
@@ -525,6 +611,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": null,
@@ -555,6 +642,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": {
@@ -573,6 +661,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": null,
@@ -603,6 +692,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": {
@@ -621,6 +711,7 @@
         "verdict": "CONCERNS",
         "exitCode": 0,
         "basis": ["coverage gap malformed-input unsatisfied at or above the severity floor"],
+        "qualification": null,
         "strength": {
           "defect": null,
           "gameability": null,

--- a/test/test-probe-corpus.js
+++ b/test/test-probe-corpus.js
@@ -51,6 +51,20 @@ function basisShapes(basis) {
   return [...new Set(basis.map((line) => line.replaceAll(/oracle O-\d+/g, 'oracle'))).values()].sort();
 }
 
+/**
+ * The reason codes AD-9's gate gave, or null when it admitted the probe.
+ *
+ * A rejected probe resolves an oracle to `infrastructure-error` wherever no
+ * higher-precedence condition already resolved it, which reads the same
+ * whichever of the twenty reasons fired. `runScore` carries the closed set out
+ * on `qualification`, so the baseline records which one it was and a rejection
+ * that changes its reason shows up as a diff.
+ */
+function qualificationCodes(qualification) {
+  const codes = qualification.failures.map((failure) => failure.code).sort();
+  return codes.length === 0 ? null : codes;
+}
+
 /** One probe's result, small enough to read in a diff and complete enough to notice a change. */
 function probeSummary(entry) {
   const failedChecks = entry.preflight.checks.filter((check) => check.outcome === 'failed').map((check) => check.kind);
@@ -62,6 +76,7 @@ function probeSummary(entry) {
     verdict: entry.result.ladder.verdict,
     exitCode: entry.result.ladder.exitCode,
     basis: basisShapes(entry.result.ladder.basis),
+    qualification: qualificationCodes(entry.result.qualification),
     strength: entry.result.artifact?.strength?.vector ?? null,
   };
 }


### PR DESCRIPTION
Three findings this repository raised against `eval-quality` landed in 1.4.0, and this bump measures what each one is worth here.

## What moved, measured on the stored replay across the two versions

| | 1.3.0 | 1.4.0 |
|---|---|---|
| `test-review` defect exercised / caught | 4 / 4 | **9 / 9** |
| `test-review` P-001 through P-005 | preflight `failed: seeded-faults-scoped`, verdict null, exit 3 | `passed`, `CONCERNS`, exit 0, each with its own strength vector |
| `trace` O-023, O-024 | `abstained` | `passed-clean-control` |
| `trace` P-001 through P-003 rejection reason | invisible | `condition-artifact-channel-contract-local` |

`test-probe-corpus` now records a `qualification` field per probe, so a rejection that changes its reason shows up as a diff instead of reading as the same `infrastructure-error` it always did.

## Four passages rewritten

Each described a limitation that no longer exists.

- `test/probes/README.md`: a rejected probe carries no reason across the boundary.
- `docs/explanation/eval-quality-command-adapter.md`: the same claim, plus the note that reading the reasons would need a third reach into `dist/`. It needed none; the reason is on the published surface now and the count stays at two.
- The same document: "this collection is empty" has no spelling. It has one, and O-023 and O-024 are the measurement.
- The same document: the argument that no leg TEA could add repairs `seeded-faults-scoped` firing on a leg carrying the fault leg's own request. That was correct, and 1.4.0 fixes it in the reducer rather than in the plan.

## Two findings that stay open, and are TEA's

`trace`'s witness fires on `witness-gate-withheld`, a leg that issues a different request and receives a different answer. The reducer keeps it in the examined set on purpose, so this is a real scoping problem in the trace contract rather than a false failure.

`trace`'s three defect probes address a file the command wrote, which the qualification gate refuses by design. The reason is visible for the first time here.

## Gate

`npm test` green, 24 checks. `npm run test:cli` green, run separately because `npm test` does not chain it.